### PR TITLE
fix lint warnings

### DIFF
--- a/pkg/duplex/server.go
+++ b/pkg/duplex/server.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 // grpcHandlerFunc routes inbound requests to either the passed gRPC server or

--- a/pkg/duplex/server.go
+++ b/pkg/duplex/server.go
@@ -71,7 +71,7 @@ func New(port int, opts ...interface{}) *Duplex {
 		// the appropriate method on this address, so we loopback to ourselves.
 		Loopback:    fmt.Sprintf("localhost:%d", port),
 		Port:        port,
-		DialOptions: []grpc.DialOption{grpc.WithInsecure()},
+		DialOptions: []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
 	}
 	return d
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -36,7 +36,10 @@ var listenersForTest sync.Map
 // Register a test listener and get a provided scheme.
 func RegisterListenerForTest(listener DialableListener) string {
 	for {
-		val, _ := rand.Int(rand.Reader, big.NewInt(int64(math.MaxInt64)))
+		val, err := rand.Int(rand.Reader, big.NewInt(int64(math.MaxInt64)))
+    if err != nil {
+      panic(err)
+    }
 		scheme := fmt.Sprintf("test%d", val.Int64())
 		if _, conflicted := listenersForTest.LoadOrStore(scheme, listener); !conflicted {
 			return scheme

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -37,9 +37,9 @@ var listenersForTest sync.Map
 func RegisterListenerForTest(listener DialableListener) string {
 	for {
 		val, err := rand.Int(rand.Reader, big.NewInt(int64(math.MaxInt64)))
-    if err != nil {
-      panic(err)
-    }
+		if err != nil {
+			panic(err)
+		}
 		scheme := fmt.Sprintf("test%d", val.Int64())
 		if _, conflicted := listenersForTest.LoadOrStore(scheme, listener); !conflicted {
 			return scheme

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -7,9 +7,9 @@ package options
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/tls"
 	"fmt"
-	"math/rand"
 	"net"
 	"net/url"
 	"sync"

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -7,9 +7,9 @@ package options
 
 import (
 	"context"
-	"crypto/rand"
 	"crypto/tls"
 	"fmt"
+	"math/rand"
 	"net"
 	"net/url"
 	"sync"

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -7,9 +7,11 @@ package options
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/tls"
 	"fmt"
-	"math/rand"
+	"math"
+	"math/big"
 	"net"
 	"net/url"
 	"sync"
@@ -34,7 +36,8 @@ var listenersForTest sync.Map
 // Register a test listener and get a provided scheme.
 func RegisterListenerForTest(listener DialableListener) string {
 	for {
-		scheme := fmt.Sprintf("test%d", rand.Uint64())
+		val, _ := rand.Int(rand.Reader, big.NewInt(int64(math.MaxInt64)))
+		scheme := fmt.Sprintf("test%d", val.Int64())
 		if _, conflicted := listenersForTest.LoadOrStore(scheme, listener); !conflicted {
 			return scheme
 		}


### PR DESCRIPTION
```
Error: pkg/options/options.go:37:35: G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec)
		scheme := fmt.Sprintf("test%d", rand.Uint64())
```

```
Error: pkg/duplex/server.go:74:34: SA1019: grpc.WithInsecure is deprecated: use WithTransportCredentials and insecure.NewCredentials() instead. Will be supported throughout 1.x. (staticcheck)
		DialOptions: []grpc.DialOption{grpc.WithInsecure()},
```

Signed-off-by: Kenny Leung <kleung@chainguard.dev>