### PR TITLE
Have SetupTracer return defer func

### DIFF
--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -25,6 +25,10 @@ import (
 // Fractions >= 1 will always sample. Fractions < 0 are treated as zero. To
 // respect the parent trace's `SampledFlag`, the `TraceIDRatioBased` sampler
 // should be used as a delegate of a `Parent` sampler.
+//
+// Expected usage:
+//
+//	defer metrics.SetupTracer(ctx)()
 func SetupTracer(ctx context.Context) func() {
 	logger := logging.FromContext(ctx)
 


### PR DESCRIPTION
This mirrors the HTTP version 
https://github.com/chainguard-dev/mono/blob/main/api-internal/pkg/metrics/metrics.go#L122

TracerProvider can still be obtained by otel.GetTracerProvider(), https://github.com/open-telemetry/opentelemetry-go/blob/v1.10.0/trace.go#L40