### PR TITLE
Remove maxdepth from golangci workflow.

### DIFF
--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -45,6 +45,6 @@ while read -r i; do
   pushd "$i"
   golangci-lint run ./... || error=1
   popd
-done <<< "$(find . -name go.mod -maxdepth 3 -exec dirname {} \;)"
+done <<< "$(find . -name go.mod -exec dirname {} \;)"
 
 exit $error


### PR DESCRIPTION
This is a no-op since this repo only has 1 repo, but applying everywhere for consistency.