### PR TITLE
GRPC options to lazily initialize the settings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module chainguard.dev/go-grpc-kit
 go 1.19
 
 require (
+	github.com/google/go-cmp v0.5.9
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.1-0.20210315223345-82c243799c99
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,7 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2022 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package options
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetEnv(t *testing.T) {
+	old := os.Getenv("GRPC_CLIENT_MAX_RETRY")
+	defer os.Setenv("GRPC_CLIENT_MAX_RETRY", old)
+
+	want := &envStruct{
+		EnableClientHandlingTimeHistogram:      true,
+		EnableClientStreamReceiveTimeHistogram: true,
+		EnableClientStreamSendTimeHistogram:    true,
+		GrpcClientMaxRetry:                     42,
+	}
+	t.Run("can change env right before usage", func(t *testing.T) {
+		os.Setenv("GRPC_CLIENT_MAX_RETRY", strconv.Itoa(int(want.GrpcClientMaxRetry)))
+		if diff := cmp.Diff(want, getEnv()); diff != "" {
+			t.Errorf("getEnv() -want,+got: %s", diff)
+		}
+	})
+	t.Run("but cannot change after usage", func(t *testing.T) {
+		os.Setenv("GRPC_CLIENT_MAX_RETRY", strconv.Itoa(int(want.GrpcClientMaxRetry+10)))
+		if diff := cmp.Diff(want, getEnv()); diff != "" {
+			t.Errorf("getEnv() -want,+got: %s", diff)
+		}
+	})
+}


### PR DESCRIPTION
This allows dependent code to change the environment variables in their `main()`. In the current shape, since there is no way to guarantee the ordering of `init()`, callers have no way to change these settings. Changing in `main()` is certainly too late.