### PR TITLE
pin reviewdog/action-tflint action to specific commit

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -84,7 +84,7 @@ jobs:
       - uses: chainguard-dev/actions/eof-newline@main
         if: ${{ always() }}
 
-      - uses: reviewdog/action-tflint@master
+      - uses: reviewdog/action-tflint@f17a66a19220804dfa5ba4912e1a9fe7c530fe0a # v1.24.0
         if: ${{ always() }}
         with:
           github_token: ${{ secrets.github_token }}


### PR DESCRIPTION
The action was pointing to master, so pinned to the current commit and also added a comment for the specific version tag associated with it, so that dependabot can keep it up to date.

Ref: https://github.com/chainguard-dev/prodsec/issues/60