### PR TITLE
Fix panic in GRPC Options

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -116,7 +116,7 @@ func enableClientTimeHistogram() {
 
 func ClientOptions() []option.ClientOption {
 	do := GRPCDialOptions()
-	cos := make([]option.ClientOption, len(do))
+	cos := make([]option.ClientOption, 0, len(do))
 
 	for _, o := range do {
 		cos = append(cos, option.WithGRPCDialOption(o))


### PR DESCRIPTION
This currently populates the first half of the slice with nil options and appends the rest to the last half.