### PR TITLE
metrics: Allow histograms to go up to 3600 and then some

### DIFF
--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -64,7 +64,8 @@ func RegisterListenAndServe(server *grpc.Server, listenAddr string, enablePprof 
 	grpc_prometheus.Register(server)
 	grpc_prometheus.EnableHandlingTimeHistogram(
 		grpc_prometheus.WithHistogramBuckets(
-			[]float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600},
+			// Odd upper bound to avoid conflating a bounded histogram with a timeout.
+			[]float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600, 1200, 2400, 3666},
 		),
 	)
 


### PR DESCRIPTION
This allows our gRPC-related histograms to report up to an hour. We're using an odd-looking number there to distinguish from bucket-boundaries and system timeouts for example.