### PR TITLE
enable gRPC client retries with jitter by default

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
@@ -36,7 +37,7 @@ type envStruct struct {
 	EnableClientHandlingTimeHistogram      bool `envconfig:"ENABLE_CLIENT_HANDLING_TIME_HISTOGRAM" default:"true"`
 	EnableClientStreamReceiveTimeHistogram bool `envconfig:"ENABLE_CLIENT_STREAM_RECEIVE_TIME_HISTOGRAM" default:"true"`
 	EnableClientStreamSendTimeHistogram    bool `envconfig:"ENABLE_CLIENT_STREAM_SEND_TIME_HISTOGRAM" default:"true"`
-	GrpcClientMaxRetry                     uint `envconfig:"GRPC_CLIENT_MAX_RETRY" default:"0"`
+	GrpcClientMaxRetry                     uint `envconfig:"GRPC_CLIENT_MAX_RETRY" default:"2"`
 }
 
 type initStuff struct {
@@ -145,8 +146,13 @@ func LoopbackDialOptions() []grpc.DialOption {
 
 func GRPCDialOptions() []grpc.DialOption {
 	retryOpts := []grpc_retry.CallOption{
-		grpc_retry.WithBackoff(grpc_retry.BackoffExponential(100 * time.Millisecond)),
+		grpc_retry.WithBackoff(grpc_retry.BackoffExponentialWithJitter(100*time.Millisecond, 0.2)),
 		grpc_retry.WithMax(state().env.GrpcClientMaxRetry),
+		// Only retry Unavailable by default (request never reached the server).
+		// codes.Internal is not retried because the request may have been
+		// partially processed. Per-client overrides can add codes.Internal
+		// for idempotent-safe services.
+		grpc_retry.WithCodes(codes.Unavailable),
 	}
 
 	return []grpc.DialOption{

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -6,11 +6,19 @@ SPDX-License-Identifier: Apache-2.0
 package options
 
 import (
+	"context"
+	"net"
 	"os"
 	"strconv"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
 )
 
 func TestGetEnv(t *testing.T) {
@@ -35,4 +43,95 @@ func TestGetEnv(t *testing.T) {
 			t.Errorf("getEnv() -want,+got: %s", diff)
 		}
 	})
+}
+
+// flakyHealthServer returns Unavailable for the first N calls, then OK.
+type flakyHealthServer struct {
+	healthpb.UnimplementedHealthServer
+	failCount int32
+	calls     atomic.Int32
+}
+
+func (s *flakyHealthServer) Check(_ context.Context, _ *healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
+	n := s.calls.Add(1)
+	if n <= s.failCount {
+		return nil, status.Error(codes.Unavailable, "temporarily unavailable")
+	}
+	return &healthpb.HealthCheckResponse{Status: healthpb.HealthCheckResponse_SERVING}, nil
+}
+
+func TestGRPCDialOptions_RetriesUnavailable(t *testing.T) {
+	// Start a gRPC server that fails the first call with Unavailable,
+	// then succeeds. With retries enabled, the client should succeed.
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := grpc.NewServer()
+	flaky := &flakyHealthServer{failCount: 1}
+	healthpb.RegisterHealthServer(srv, flaky)
+	go srv.Serve(lis)
+	defer srv.Stop()
+
+	// Dial with GRPCDialOptions (which include the retry interceptor).
+	opts := GRPCDialOptions()
+	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(lis.Addr().String(), opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	client := healthpb.NewHealthClient(conn)
+	resp, err := client.Check(context.Background(), &healthpb.HealthCheckRequest{})
+	if err != nil {
+		t.Fatalf("expected retry to succeed after transient Unavailable, got: %v", err)
+	}
+	if resp.Status != healthpb.HealthCheckResponse_SERVING {
+		t.Errorf("got status %v, want SERVING", resp.Status)
+	}
+	if got := flaky.calls.Load(); got != 2 {
+		t.Errorf("expected 2 calls (1 fail + 1 success), got %d", got)
+	}
+}
+
+func TestGRPCDialOptions_DoesNotRetryInternal(t *testing.T) {
+	// Start a gRPC server that always fails with Internal.
+	// With the default config, Internal should NOT be retried.
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := grpc.NewServer()
+	healthpb.RegisterHealthServer(srv, &internalErrorServer{})
+	go srv.Serve(lis)
+	defer srv.Stop()
+
+	opts := GRPCDialOptions()
+	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(lis.Addr().String(), opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	client := healthpb.NewHealthClient(conn)
+	_, err = client.Check(context.Background(), &healthpb.HealthCheckRequest{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got := status.Code(err); got != codes.Internal {
+		t.Errorf("expected codes.Internal, got %v", got)
+	}
+}
+
+// internalErrorServer always returns Internal.
+type internalErrorServer struct {
+	healthpb.UnimplementedHealthServer
+	calls atomic.Int32
+}
+
+func (s *internalErrorServer) Check(_ context.Context, _ *healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
+	s.calls.Add(1)
+	return nil, status.Error(codes.Internal, "internal error")
 }

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -103,7 +103,8 @@ func TestGRPCDialOptions_DoesNotRetryInternal(t *testing.T) {
 		t.Fatal(err)
 	}
 	srv := grpc.NewServer()
-	healthpb.RegisterHealthServer(srv, &internalErrorServer{})
+	internal := &internalErrorServer{}
+	healthpb.RegisterHealthServer(srv, internal)
 	go srv.Serve(lis)
 	defer srv.Stop()
 
@@ -122,6 +123,9 @@ func TestGRPCDialOptions_DoesNotRetryInternal(t *testing.T) {
 	}
 	if got := status.Code(err); got != codes.Internal {
 		t.Errorf("expected codes.Internal, got %v", got)
+	}
+	if got := internal.calls.Load(); got != 1 {
+		t.Errorf("expected 1 call (no retries for Internal), got %d", got)
 	}
 }
 


### PR DESCRIPTION
  ## Summary

  Change the default gRPC client retry configuration to provide baseline
  resilience against transient `Unavailable` errors (connection failures,
  load balancer overloads, Cloud Run cold starts).

  - Default `GRPC_CLIENT_MAX_RETRY` from 0 → 2
  - Change backoff from `BackoffExponential(100ms)` to
    `BackoffExponentialWithJitter(100ms, 0.2)` to desynchronize retriers
    and prevent thundering herd on recovery
  - Explicitly retry only `codes.Unavailable` (request never reached server)

  ## Motivation

  Addresses [CUS-172](https://linear.app/chainguard/issue/CUS-172) /
  [chainguard-dev/internal-dev#18988](https://github.com/chainguard-dev/internal-dev/issues/18988),
  a follow-up from INC-44 where internal usage spikes overwhelmed the
  shared load balancer and caused cascading dial timeouts.

  ## Current state in mono (11 gRPC clients from the API server)

  | Client | Retry max | Backoff | Codes |
  |--------|-----------|---------|-------|
  | IAM datastore | **0 (default)** | — | — |
  | Registry datastore | 2 | Linear 50ms | Unavailable, Internal |
  | Ecosystems datastore | 2 | Linear 50ms | Unavailable, Internal |
  | Packages datastore | 2 | Linear 50ms | Unavailable, Internal |
  | Policy gates | 2 | Linear 50ms | Unavailable, Internal |
  | Apkoaas | 2 | Linear 50ms | Unavailable, Internal |
  | Vulnerabilities datastore | **0 (default)** | — | — |
  | OIDC | **0 (default)** | — | — |
  | Image recommender | **0 (default)** | — | — |
  | Workqueue | **0 (default)** | — | — |
  | GitHub identity | **0 (default)** | — | — |

  **Problems:**
  - 6/11 clients have zero retries — transient connection failures surface
    as user-visible errors immediately
  - The 5 clients with retries use linear 50ms backoff with no jitter,
    causing synchronized retry waves (thundering herd)
  - No client has keepalive configured except apkoaas (6 min), so idle
    connections are silently dropped by Cloud Run after ~10 min, causing
    reconnection storms under load

  ## Design decisions

  **Why `codes.Unavailable` only (not `codes.Internal`):**
  `Unavailable` means the request never reached the server — always safe
  to retry. `Internal` means the server received and potentially processed
  the request. Retrying non-idempotent mutations (e.g., datastore `Create`
  RPCs) after an `Internal` error could produce `AlreadyExists` instead of
  success if the first attempt committed but the response was lost. The 5
  per-client overrides in mono that add `codes.Internal` made an explicit
  choice that this tradeoff is acceptable for those services.

  **Why default 2 (not higher):**
  Matches the retry count already used by the 5 production clients that
  have been tuned. With exponential backoff (100ms base + 20% jitter),
  2 retries complete within ~300ms, keeping tail latency reasonable.

  **Override:** Services can set `GRPC_CLIENT_MAX_RETRY=0` to disable
  retries entirely if needed.

  ## Follow-up in mono

  After this lands and mono bumps `go-grpc-kit`, the per-client retry
  overrides in mono can be simplified:

  - **Registry, ecosystems, packages, policygates, apkoaas**: Remove the
    `grpc_retry.WithBackoff(BackoffLinear(50ms))` and
    `grpc_retry.WithMax(2)` — they now get 2 retries with jitter from the
    default. They only need to keep `grpc_retry.WithCodes(Unavailable, Internal)`
    to retain the `Internal` retry behavior.
  - **IAM, vulnerabilities, OIDC, recommender, workqueue, GitHub identity**:
    Automatically gain 2 retries on `Unavailable` with no code changes.

  ## Test plan

  - [ ] `cd pkg/options && go test ./...`
  - [ ] Deploy to staging, verify retry metrics in Prometheus
        (`grpc_client_handled_total` with retry labels)
  - [ ] Confirm no increase in duplicate mutations

  🤖 Generated with [Claude Code](https://claude.com/claude-code)


for 
https://linear.app/chainguard/issue/CUS-234/enable-grpc-client-retries-with-jitter-by-default
https://linear.app/chainguard/issue/CUS-235/add-keepalive-to-all-grpc-clients