### PR TITLE
add default deadline interceptor for gRPC clients

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -33,10 +33,11 @@ import (
 )
 
 type envStruct struct {
-	EnableClientHandlingTimeHistogram      bool `envconfig:"ENABLE_CLIENT_HANDLING_TIME_HISTOGRAM" default:"true"`
-	EnableClientStreamReceiveTimeHistogram bool `envconfig:"ENABLE_CLIENT_STREAM_RECEIVE_TIME_HISTOGRAM" default:"true"`
-	EnableClientStreamSendTimeHistogram    bool `envconfig:"ENABLE_CLIENT_STREAM_SEND_TIME_HISTOGRAM" default:"true"`
-	GrpcClientMaxRetry                     uint `envconfig:"GRPC_CLIENT_MAX_RETRY" default:"0"`
+	EnableClientHandlingTimeHistogram      bool          `envconfig:"ENABLE_CLIENT_HANDLING_TIME_HISTOGRAM" default:"true"`
+	EnableClientStreamReceiveTimeHistogram bool          `envconfig:"ENABLE_CLIENT_STREAM_RECEIVE_TIME_HISTOGRAM" default:"true"`
+	EnableClientStreamSendTimeHistogram    bool          `envconfig:"ENABLE_CLIENT_STREAM_SEND_TIME_HISTOGRAM" default:"true"`
+	GrpcClientMaxRetry                     uint          `envconfig:"GRPC_CLIENT_MAX_RETRY" default:"0"`
+	GrpcClientDefaultTimeout               time.Duration `envconfig:"GRPC_CLIENT_DEFAULT_TIMEOUT" default:"30s"`
 }
 
 type initStuff struct {
@@ -152,8 +153,24 @@ func GRPCDialOptions() []grpc.DialOption {
 	return []grpc.DialOption{
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 		grpc.WithStatsHandler(trace.PreserveTraceParentHandler),
-		grpc.WithChainUnaryInterceptor(clientid.UnaryClientInterceptor(), state().clientMetrics.UnaryClientInterceptor(), grpc_retry.UnaryClientInterceptor(retryOpts...)),
+		grpc.WithChainUnaryInterceptor(defaultDeadlineInterceptor(state().env.GrpcClientDefaultTimeout), clientid.UnaryClientInterceptor(), state().clientMetrics.UnaryClientInterceptor(), grpc_retry.UnaryClientInterceptor(retryOpts...)),
 		grpc.WithChainStreamInterceptor(clientid.StreamClientInterceptor(), state().clientMetrics.StreamClientInterceptor(), grpc_retry.StreamClientInterceptor(retryOpts...)),
+	}
+}
+
+// defaultDeadlineInterceptor returns a unary client interceptor that sets a
+// default deadline on calls that don't already have one. This prevents
+// WaitForReady(true) from blocking indefinitely when a downstream is
+// unavailable, which would tie up goroutines until the Cloud Run concurrency
+// limit is exhausted.
+func defaultDeadlineInterceptor(timeout time.Duration) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		if _, ok := ctx.Deadline(); !ok && timeout > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, timeout)
+			defer cancel()
+		}
+		return invoker(ctx, method, req, reply, cc, opts...)
 	}
 }
 

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -6,11 +6,19 @@ SPDX-License-Identifier: Apache-2.0
 package options
 
 import (
+	"context"
+	"net"
 	"os"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
 )
 
 func TestGetEnv(t *testing.T) {
@@ -22,6 +30,7 @@ func TestGetEnv(t *testing.T) {
 		EnableClientStreamReceiveTimeHistogram: true,
 		EnableClientStreamSendTimeHistogram:    true,
 		GrpcClientMaxRetry:                     42,
+		GrpcClientDefaultTimeout:               30 * time.Second,
 	}
 	t.Run("can change env right before usage", func(t *testing.T) {
 		os.Setenv("GRPC_CLIENT_MAX_RETRY", strconv.Itoa(int(want.GrpcClientMaxRetry)))
@@ -35,4 +44,121 @@ func TestGetEnv(t *testing.T) {
 			t.Errorf("getEnv() -want,+got: %s", diff)
 		}
 	})
+}
+
+// slowServer sleeps before responding, allowing deadline tests.
+type slowServer struct {
+	healthpb.UnimplementedHealthServer
+	delay time.Duration
+}
+
+func (s *slowServer) Check(ctx context.Context, _ *healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
+	select {
+	case <-time.After(s.delay):
+		return &healthpb.HealthCheckResponse{Status: healthpb.HealthCheckResponse_SERVING}, nil
+	case <-ctx.Done():
+		return nil, status.FromContextError(ctx.Err()).Err()
+	}
+}
+
+func TestDefaultDeadlineInterceptor_AppliesTimeout(t *testing.T) {
+	// Server takes 5s to respond. The default timeout is 30s, but we
+	// override to 100ms via env var for this test. The call should fail
+	// with DeadlineExceeded.
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := grpc.NewServer()
+	healthpb.RegisterHealthServer(srv, &slowServer{delay: 5 * time.Second})
+	go srv.Serve(lis)
+	defer srv.Stop()
+
+	interceptor := defaultDeadlineInterceptor(100 * time.Millisecond)
+	conn, err := grpc.NewClient(lis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(interceptor),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	client := healthpb.NewHealthClient(conn)
+	_, err = client.Check(context.Background(), &healthpb.HealthCheckRequest{})
+	if err == nil {
+		t.Fatal("expected DeadlineExceeded, got nil")
+	}
+	if got := status.Code(err); got != codes.DeadlineExceeded {
+		t.Errorf("expected DeadlineExceeded, got %v", got)
+	}
+}
+
+func TestDefaultDeadlineInterceptor_RespectsExistingDeadline(t *testing.T) {
+	// If the caller already set a deadline, the interceptor should not
+	// override it. Use a 5s caller deadline with a 100ms interceptor timeout.
+	// The server responds in 50ms — should succeed because the caller's
+	// 5s deadline governs, not the interceptor's 100ms.
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := grpc.NewServer()
+	healthpb.RegisterHealthServer(srv, &slowServer{delay: 50 * time.Millisecond})
+	go srv.Serve(lis)
+	defer srv.Stop()
+
+	interceptor := defaultDeadlineInterceptor(100 * time.Millisecond)
+	conn, err := grpc.NewClient(lis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(interceptor),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client := healthpb.NewHealthClient(conn)
+	resp, err := client.Check(ctx, &healthpb.HealthCheckRequest{})
+	if err != nil {
+		t.Fatalf("expected success with caller deadline, got: %v", err)
+	}
+	if resp.Status != healthpb.HealthCheckResponse_SERVING {
+		t.Errorf("got %v, want SERVING", resp.Status)
+	}
+}
+
+func TestDefaultDeadlineInterceptor_DisabledWithZero(t *testing.T) {
+	// With timeout=0, no deadline is applied. The call should succeed
+	// even though the server takes a moment to respond.
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := grpc.NewServer()
+	healthpb.RegisterHealthServer(srv, &slowServer{delay: 50 * time.Millisecond})
+	go srv.Serve(lis)
+	defer srv.Stop()
+
+	interceptor := defaultDeadlineInterceptor(0)
+	conn, err := grpc.NewClient(lis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(interceptor),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	client := healthpb.NewHealthClient(conn)
+	resp, err := client.Check(context.Background(), &healthpb.HealthCheckRequest{})
+	if err != nil {
+		t.Fatalf("expected success with disabled timeout, got: %v", err)
+	}
+	if resp.Status != healthpb.HealthCheckResponse_SERVING {
+		t.Errorf("got %v, want SERVING", resp.Status)
+	}
 }

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -61,31 +61,36 @@ func (s *slowServer) Check(ctx context.Context, _ *healthpb.HealthCheckRequest) 
 	}
 }
 
-func TestDefaultDeadlineInterceptor_AppliesTimeout(t *testing.T) {
-	// Server takes 5s to respond. The default timeout is 30s, but we
-	// override to 100ms via env var for this test. The call should fail
-	// with DeadlineExceeded.
+// dialWithDeadlineInterceptor starts a gRPC server with the given delay and
+// returns a health client wired through the deadline interceptor.
+func dialWithDeadlineInterceptor(t *testing.T, serverDelay, interceptorTimeout time.Duration) healthpb.HealthClient {
+	t.Helper()
 	lis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatal(err)
 	}
 	srv := grpc.NewServer()
-	healthpb.RegisterHealthServer(srv, &slowServer{delay: 5 * time.Second})
+	healthpb.RegisterHealthServer(srv, &slowServer{delay: serverDelay})
 	go srv.Serve(lis)
-	defer srv.Stop()
+	t.Cleanup(srv.Stop)
 
-	interceptor := defaultDeadlineInterceptor(100 * time.Millisecond)
 	conn, err := grpc.NewClient(lis.Addr().String(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(interceptor),
+		grpc.WithUnaryInterceptor(defaultDeadlineInterceptor(interceptorTimeout)),
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer conn.Close()
+	t.Cleanup(func() { conn.Close() })
+	return healthpb.NewHealthClient(conn)
+}
 
-	client := healthpb.NewHealthClient(conn)
-	_, err = client.Check(context.Background(), &healthpb.HealthCheckRequest{})
+func TestDefaultDeadlineInterceptor_AppliesTimeout(t *testing.T) {
+	// Server takes 5s to respond, interceptor timeout is 100ms.
+	// No caller deadline → interceptor applies 100ms → DeadlineExceeded.
+	client := dialWithDeadlineInterceptor(t, 5*time.Second, 100*time.Millisecond)
+
+	_, err := client.Check(context.Background(), &healthpb.HealthCheckRequest{})
 	if err == nil {
 		t.Fatal("expected DeadlineExceeded, got nil")
 	}
@@ -95,33 +100,16 @@ func TestDefaultDeadlineInterceptor_AppliesTimeout(t *testing.T) {
 }
 
 func TestDefaultDeadlineInterceptor_RespectsExistingDeadline(t *testing.T) {
-	// If the caller already set a deadline, the interceptor should not
-	// override it. Use a 5s caller deadline with a 100ms interceptor timeout.
-	// The server responds in 50ms — should succeed because the caller's
-	// 5s deadline governs, not the interceptor's 100ms.
-	lis, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	srv := grpc.NewServer()
-	healthpb.RegisterHealthServer(srv, &slowServer{delay: 50 * time.Millisecond})
-	go srv.Serve(lis)
-	defer srv.Stop()
-
-	interceptor := defaultDeadlineInterceptor(100 * time.Millisecond)
-	conn, err := grpc.NewClient(lis.Addr().String(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(interceptor),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer conn.Close()
+	// Server responds in 200ms, interceptor timeout is 100ms, caller
+	// deadline is 5s. If the interceptor incorrectly overwrote the
+	// caller's deadline, the 200ms response would exceed the 100ms
+	// interceptor timeout and fail. Since the caller's deadline governs,
+	// the call succeeds.
+	client := dialWithDeadlineInterceptor(t, 200*time.Millisecond, 100*time.Millisecond)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	client := healthpb.NewHealthClient(conn)
 	resp, err := client.Check(ctx, &healthpb.HealthCheckRequest{})
 	if err != nil {
 		t.Fatalf("expected success with caller deadline, got: %v", err)
@@ -132,28 +120,9 @@ func TestDefaultDeadlineInterceptor_RespectsExistingDeadline(t *testing.T) {
 }
 
 func TestDefaultDeadlineInterceptor_DisabledWithZero(t *testing.T) {
-	// With timeout=0, no deadline is applied. The call should succeed
-	// even though the server takes a moment to respond.
-	lis, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	srv := grpc.NewServer()
-	healthpb.RegisterHealthServer(srv, &slowServer{delay: 50 * time.Millisecond})
-	go srv.Serve(lis)
-	defer srv.Stop()
+	// timeout=0 disables the interceptor. Call succeeds despite no deadline.
+	client := dialWithDeadlineInterceptor(t, 50*time.Millisecond, 0)
 
-	interceptor := defaultDeadlineInterceptor(0)
-	conn, err := grpc.NewClient(lis.Addr().String(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(interceptor),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer conn.Close()
-
-	client := healthpb.NewHealthClient(conn)
 	resp, err := client.Check(context.Background(), &healthpb.HealthCheckRequest{})
 	if err != nil {
 		t.Fatalf("expected success with disabled timeout, got: %v", err)


### PR DESCRIPTION
  ## Summary

  Add a unary client interceptor that sets a default 30s deadline on gRPC
  calls that don't already have one. This prevents `WaitForReady(true)` from
  blocking indefinitely when a downstream is unavailable.

  ## Motivation

  Addresses [CUS-238](https://linear.app/chainguard/issue/CUS-238) /
  [CUS-172](https://linear.app/chainguard/issue/CUS-172) /
  [chainguard-dev/internal-dev#18988](https://github.com/chainguard-dev/internal-dev/issues/18988).

  `WaitForReady(true)` is set globally on all gRPC clients. When a downstream
  is unavailable, RPCs block indefinitely waiting for the connection to become
  ready, tying up goroutines until Cloud Run's per-instance concurrency limit
  (50) is exhausted. During INC-44, this caused API instances to accumulate
  blocked goroutines faster than Cloud Run could scale new instances.

  ## Changes

  - New env var `GRPC_CLIENT_DEFAULT_TIMEOUT` (default `30s`)
  - New `defaultDeadlineInterceptor` placed first in the unary interceptor
    chain — if the caller's context has no deadline, one is applied
  - Only affects unary calls (streams are long-lived and shouldn't have a
    blanket timeout)

  ## Behavior

  | Scenario | Result |
  |----------|--------|
  | Caller has no deadline | 30s deadline applied |
  | Caller sets own deadline (e.g., 60s) | Caller's deadline preserved |
  | `GRPC_CLIENT_DEFAULT_TIMEOUT=0` | Interceptor is a no-op |
  | `GRPC_CLIENT_DEFAULT_TIMEOUT=10s` | 10s deadline applied |

  ## Risk

  Services with intentionally long RPCs (e.g., apkoaas builds, image
  assembly) should set an explicit context deadline or override the env var.
  The 30s default is conservative — the API server's request timeout is 60
  minutes for the build use case, but the API server always sets a context
  deadline from the incoming request, so the interceptor won't override it.

  ## Tests

  - `TestDefaultDeadlineInterceptor_AppliesTimeout` — slow server + short
    timeout → `DeadlineExceeded`
  - `TestDefaultDeadlineInterceptor_RespectsExistingDeadline` — caller's
    longer deadline is preserved, call succeeds
  - `TestDefaultDeadlineInterceptor_DisabledWithZero` — timeout=0 disables
    the interceptor, call succeeds

  ## Test plan

  - [x] `go test ./pkg/options/ -v` — 5/5 pass
  - [x] `golangci-lint run ./pkg/options/` — 0 issues
  - [ ] CI passes
  - [ ] Deploy to staging, verify no unexpected `DeadlineExceeded` errors

  🤖 Generated with [Claude Code](https://claude.com/claude-code)