### PR TITLE
add per-client concurrency limiter interceptor for gRPC clients

### DIFF
--- a/pkg/interceptors/concurrency/concurrency.go
+++ b/pkg/interceptors/concurrency/concurrency.go
@@ -79,7 +79,7 @@ func (l *Limiter) StreamClientInterceptor() grpc.StreamClientInterceptor {
 				<-l.sem
 				return nil, err
 			}
-			return &releasingStream{ClientStream: stream, sem: l.sem}, nil
+			return newReleasingStream(stream, l.sem), nil
 		case <-ctx.Done():
 			return nil, status.FromContextError(ctx.Err()).Err()
 		}
@@ -99,15 +99,25 @@ func (l *Limiter) InFlight() int {
 }
 
 // releasingStream wraps a ClientStream and releases the semaphore slot
-// when the stream receives an error (including io.EOF) from RecvMsg.
-//
-// Callers must drain RecvMsg until it returns an error (typically io.EOF)
-// to release the slot. Abandoning a stream without draining will leak the
-// slot until the process exits.
+// when the stream terminates. The slot is released on the first of:
+//   - RecvMsg returns an error (including io.EOF)
+//   - The stream context is canceled (safety net for abandoned streams)
 type releasingStream struct {
 	grpc.ClientStream
 	sem     chan struct{}
 	release sync.Once
+}
+
+func newReleasingStream(stream grpc.ClientStream, sem chan struct{}) *releasingStream {
+	rs := &releasingStream{ClientStream: stream, sem: sem}
+	// Safety net: release the slot if the stream context is canceled
+	// without RecvMsg being drained. This prevents permanent slot leaks
+	// from abandoned streams.
+	go func() {
+		<-stream.Context().Done()
+		rs.release.Do(func() { <-rs.sem })
+	}()
+	return rs
 }
 
 func (s *releasingStream) RecvMsg(m any) error {

--- a/pkg/interceptors/concurrency/concurrency.go
+++ b/pkg/interceptors/concurrency/concurrency.go
@@ -12,6 +12,7 @@ package concurrency
 
 import (
 	"context"
+	"sync"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
@@ -57,7 +58,8 @@ func (l *Limiter) UnaryClientInterceptor() grpc.UnaryClientInterceptor {
 
 // StreamClientInterceptor returns a gRPC stream client interceptor that
 // acquires a concurrency slot before establishing the stream. The slot is
-// held for the lifetime of the stream.
+// released when RecvMsg returns an error (including io.EOF). Callers must
+// drain RecvMsg to completion to avoid leaking slots.
 func (l *Limiter) StreamClientInterceptor() grpc.StreamClientInterceptor {
 	return func(
 		ctx context.Context,
@@ -86,6 +88,9 @@ func (l *Limiter) StreamClientInterceptor() grpc.StreamClientInterceptor {
 
 // InFlight returns the current number of in-flight RPCs.
 // Returns 0 if the limiter is disabled.
+//
+// Note: the value is approximate under contention since len() on a buffered
+// channel is not synchronized with concurrent send/receive operations.
 func (l *Limiter) InFlight() int {
 	if l.sem == nil {
 		return 0
@@ -95,17 +100,20 @@ func (l *Limiter) InFlight() int {
 
 // releasingStream wraps a ClientStream and releases the semaphore slot
 // when the stream receives an error (including io.EOF) from RecvMsg.
+//
+// Callers must drain RecvMsg until it returns an error (typically io.EOF)
+// to release the slot. Abandoning a stream without draining will leak the
+// slot until the process exits.
 type releasingStream struct {
 	grpc.ClientStream
-	sem      chan struct{}
-	released bool
+	sem     chan struct{}
+	release sync.Once
 }
 
 func (s *releasingStream) RecvMsg(m any) error {
 	err := s.ClientStream.RecvMsg(m)
-	if err != nil && !s.released {
-		s.released = true
-		<-s.sem
+	if err != nil {
+		s.release.Do(func() { <-s.sem })
 	}
 	return err
 }

--- a/pkg/interceptors/concurrency/concurrency.go
+++ b/pkg/interceptors/concurrency/concurrency.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2026 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package concurrency provides a gRPC client interceptor that limits the
+// number of concurrent in-flight RPCs per connection. When the limit is
+// reached, new calls block until a slot opens or the context is canceled.
+// This prevents a single client instance from consuming a disproportionate
+// share of downstream capacity during traffic spikes.
+package concurrency
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+)
+
+// Limiter controls the maximum number of concurrent in-flight RPCs.
+type Limiter struct {
+	sem chan struct{}
+}
+
+// NewLimiter creates a concurrency limiter with the given maximum.
+// A maxConcurrent of 0 disables limiting (all calls pass through).
+func NewLimiter(maxConcurrent int) *Limiter {
+	if maxConcurrent <= 0 {
+		return &Limiter{}
+	}
+	return &Limiter{sem: make(chan struct{}, maxConcurrent)}
+}
+
+// UnaryClientInterceptor returns a gRPC unary client interceptor that
+// blocks until a concurrency slot is available or the context is canceled.
+func (l *Limiter) UnaryClientInterceptor() grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		if l.sem == nil {
+			return invoker(ctx, method, req, reply, cc, opts...)
+		}
+		select {
+		case l.sem <- struct{}{}:
+			defer func() { <-l.sem }()
+			return invoker(ctx, method, req, reply, cc, opts...)
+		case <-ctx.Done():
+			return status.FromContextError(ctx.Err()).Err()
+		}
+	}
+}
+
+// StreamClientInterceptor returns a gRPC stream client interceptor that
+// acquires a concurrency slot before establishing the stream. The slot is
+// held for the lifetime of the stream.
+func (l *Limiter) StreamClientInterceptor() grpc.StreamClientInterceptor {
+	return func(
+		ctx context.Context,
+		desc *grpc.StreamDesc,
+		cc *grpc.ClientConn,
+		method string,
+		streamer grpc.Streamer,
+		opts ...grpc.CallOption,
+	) (grpc.ClientStream, error) {
+		if l.sem == nil {
+			return streamer(ctx, desc, cc, method, opts...)
+		}
+		select {
+		case l.sem <- struct{}{}:
+			stream, err := streamer(ctx, desc, cc, method, opts...)
+			if err != nil {
+				<-l.sem
+				return nil, err
+			}
+			return &releasingStream{ClientStream: stream, sem: l.sem}, nil
+		case <-ctx.Done():
+			return nil, status.FromContextError(ctx.Err()).Err()
+		}
+	}
+}
+
+// InFlight returns the current number of in-flight RPCs.
+// Returns 0 if the limiter is disabled.
+func (l *Limiter) InFlight() int {
+	if l.sem == nil {
+		return 0
+	}
+	return len(l.sem)
+}
+
+// releasingStream wraps a ClientStream and releases the semaphore slot
+// when the stream receives an error (including io.EOF) from RecvMsg.
+type releasingStream struct {
+	grpc.ClientStream
+	sem      chan struct{}
+	released bool
+}
+
+func (s *releasingStream) RecvMsg(m any) error {
+	err := s.ClientStream.RecvMsg(m)
+	if err != nil && !s.released {
+		s.released = true
+		<-s.sem
+	}
+	return err
+}
+
+// Capacity returns the maximum number of concurrent RPCs allowed.
+// Returns 0 if the limiter is disabled.
+func (l *Limiter) Capacity() int {
+	if l.sem == nil {
+		return 0
+	}
+	return cap(l.sem)
+}

--- a/pkg/interceptors/concurrency/concurrency_test.go
+++ b/pkg/interceptors/concurrency/concurrency_test.go
@@ -214,6 +214,60 @@ func TestLimiter_StreamReleasesSlotOnRecvError(t *testing.T) {
 	}
 }
 
+func TestLimiter_StreamReleasesSlotOnContextCancel(t *testing.T) {
+	// Verify that canceling the stream context releases the slot even
+	// if RecvMsg is never drained — the safety net goroutine should fire.
+	srv := &slowServer{delay: 10 * time.Millisecond}
+	addr, stop := startServer(t, srv)
+	defer stop()
+
+	limiter := NewLimiter(1)
+	conn, err := grpc.NewClient(addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithStreamInterceptor(limiter.StreamClientInterceptor()),
+		grpc.WithUnaryInterceptor(limiter.UnaryClientInterceptor()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	client := healthpb.NewHealthClient(conn)
+
+	// Start a Watch stream — acquires the only slot.
+	ctx, cancel := context.WithCancel(context.Background())
+	_, err = client.Watch(ctx, &healthpb.HealthCheckRequest{})
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	if got := limiter.InFlight(); got != 1 {
+		t.Errorf("InFlight() after Watch = %d, want 1", got)
+	}
+
+	// Cancel the context WITHOUT draining RecvMsg.
+	cancel()
+
+	// The safety net goroutine should release the slot shortly.
+	deadline := time.After(2 * time.Second)
+	for limiter.InFlight() != 0 {
+		select {
+		case <-deadline:
+			t.Fatal("slot was not released within 2 seconds after context cancellation")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	// Verify the slot is reusable — a unary call should succeed.
+	resp, err := client.Check(context.Background(), &healthpb.HealthCheckRequest{})
+	if err != nil {
+		t.Fatalf("Check after context cancel release: %v", err)
+	}
+	if resp.Status != healthpb.HealthCheckResponse_SERVING {
+		t.Errorf("got %v, want SERVING", resp.Status)
+	}
+}
+
 func TestLimiter_Capacity(t *testing.T) {
 	l := NewLimiter(42)
 	if got := l.Capacity(); got != 42 {

--- a/pkg/interceptors/concurrency/concurrency_test.go
+++ b/pkg/interceptors/concurrency/concurrency_test.go
@@ -68,28 +68,22 @@ func TestLimiter_LimitsConcurrency(t *testing.T) {
 
 	// Launch 5 concurrent calls with a limit of 2.
 	var wg sync.WaitGroup
-	var maxObserved atomic.Int32
 	for range 5 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			// Sample in-flight count during the call.
-			inflight := int32(limiter.InFlight())
-			for {
-				cur := maxObserved.Load()
-				if inflight <= cur {
-					break
-				}
-				if maxObserved.CompareAndSwap(cur, inflight) {
-					break
-				}
-			}
 			client.Check(context.Background(), &healthpb.HealthCheckRequest{})
 		}()
 	}
-	// Give goroutines time to saturate the limiter.
+	// Give goroutines time to saturate the limiter, then verify the
+	// server-side serving count never exceeds the limit. srv.serving
+	// is incremented inside the server handler, so it reflects actual
+	// concurrent RPCs reaching the server (not just semaphore occupancy).
 	time.Sleep(50 * time.Millisecond)
 
+	if got := srv.serving.Load(); got > 2 {
+		t.Errorf("server serving count = %d, want <= 2", got)
+	}
 	if got := limiter.InFlight(); got > 2 {
 		t.Errorf("InFlight() = %d, want <= 2", got)
 	}
@@ -161,6 +155,62 @@ func TestLimiter_DisabledWithZero(t *testing.T) {
 	}
 	if got := limiter.Capacity(); got != 0 {
 		t.Errorf("Capacity() = %d, want 0 (disabled)", got)
+	}
+}
+
+func TestLimiter_StreamReleasesSlotOnRecvError(t *testing.T) {
+	// The stream interceptor should hold a slot while the stream is alive
+	// and release it when RecvMsg returns an error.
+	srv := &slowServer{delay: 10 * time.Millisecond}
+	addr, stop := startServer(t, srv)
+	defer stop()
+
+	limiter := NewLimiter(1)
+	conn, err := grpc.NewClient(addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithStreamInterceptor(limiter.StreamClientInterceptor()),
+		grpc.WithUnaryInterceptor(limiter.UnaryClientInterceptor()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	client := healthpb.NewHealthClient(conn)
+
+	// Start a Watch stream — this acquires the only slot.
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	stream, err := client.Watch(ctx, &healthpb.HealthCheckRequest{})
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	// Slot should be occupied.
+	if got := limiter.InFlight(); got != 1 {
+		t.Errorf("InFlight() after Watch = %d, want 1", got)
+	}
+
+	// Drain RecvMsg until error (context timeout or server close).
+	for {
+		_, err := stream.Recv()
+		if err != nil {
+			break
+		}
+	}
+
+	// Slot should now be released.
+	if got := limiter.InFlight(); got != 0 {
+		t.Errorf("InFlight() after stream drain = %d, want 0", got)
+	}
+
+	// Verify the slot is actually usable — a unary call should succeed.
+	resp, err := client.Check(context.Background(), &healthpb.HealthCheckRequest{})
+	if err != nil {
+		t.Fatalf("Check after stream release: %v", err)
+	}
+	if resp.Status != healthpb.HealthCheckResponse_SERVING {
+		t.Errorf("got %v, want SERVING", resp.Status)
 	}
 }
 

--- a/pkg/interceptors/concurrency/concurrency_test.go
+++ b/pkg/interceptors/concurrency/concurrency_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2026 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package concurrency
+
+import (
+	"context"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+)
+
+// slowServer holds each request for the configured delay.
+type slowServer struct {
+	healthpb.UnimplementedHealthServer
+	delay   time.Duration
+	serving atomic.Int32
+}
+
+func (s *slowServer) Check(ctx context.Context, _ *healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
+	s.serving.Add(1)
+	defer s.serving.Add(-1)
+	select {
+	case <-time.After(s.delay):
+		return &healthpb.HealthCheckResponse{Status: healthpb.HealthCheckResponse_SERVING}, nil
+	case <-ctx.Done():
+		return nil, status.FromContextError(ctx.Err()).Err()
+	}
+}
+
+func startServer(t *testing.T, srv healthpb.HealthServer) (string, func()) {
+	t.Helper()
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := grpc.NewServer()
+	healthpb.RegisterHealthServer(s, srv)
+	go s.Serve(lis)
+	return lis.Addr().String(), s.Stop
+}
+
+func TestLimiter_LimitsConcurrency(t *testing.T) {
+	srv := &slowServer{delay: 200 * time.Millisecond}
+	addr, stop := startServer(t, srv)
+	defer stop()
+
+	limiter := NewLimiter(2)
+	conn, err := grpc.NewClient(addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(limiter.UnaryClientInterceptor()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	client := healthpb.NewHealthClient(conn)
+
+	// Launch 5 concurrent calls with a limit of 2.
+	var wg sync.WaitGroup
+	var maxObserved atomic.Int32
+	for range 5 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Sample in-flight count during the call.
+			inflight := int32(limiter.InFlight())
+			for {
+				cur := maxObserved.Load()
+				if inflight <= cur {
+					break
+				}
+				if maxObserved.CompareAndSwap(cur, inflight) {
+					break
+				}
+			}
+			client.Check(context.Background(), &healthpb.HealthCheckRequest{})
+		}()
+	}
+	// Give goroutines time to saturate the limiter.
+	time.Sleep(50 * time.Millisecond)
+
+	if got := limiter.InFlight(); got > 2 {
+		t.Errorf("InFlight() = %d, want <= 2", got)
+	}
+
+	wg.Wait()
+}
+
+func TestLimiter_RespectsContextCancellation(t *testing.T) {
+	srv := &slowServer{delay: 5 * time.Second}
+	addr, stop := startServer(t, srv)
+	defer stop()
+
+	// Limit to 1 concurrent call.
+	limiter := NewLimiter(1)
+	conn, err := grpc.NewClient(addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(limiter.UnaryClientInterceptor()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	client := healthpb.NewHealthClient(conn)
+
+	// First call takes the only slot.
+	go client.Check(context.Background(), &healthpb.HealthCheckRequest{})
+	time.Sleep(50 * time.Millisecond) // Let it acquire the slot.
+
+	// Second call with a short context should fail waiting for the slot.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err = client.Check(ctx, &healthpb.HealthCheckRequest{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	code := status.Code(err)
+	if code != codes.DeadlineExceeded && code != codes.Canceled {
+		t.Errorf("expected DeadlineExceeded or Canceled, got %v", code)
+	}
+}
+
+func TestLimiter_DisabledWithZero(t *testing.T) {
+	srv := &slowServer{delay: 10 * time.Millisecond}
+	addr, stop := startServer(t, srv)
+	defer stop()
+
+	limiter := NewLimiter(0)
+	conn, err := grpc.NewClient(addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(limiter.UnaryClientInterceptor()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	client := healthpb.NewHealthClient(conn)
+
+	// Should pass through with no limit.
+	resp, err := client.Check(context.Background(), &healthpb.HealthCheckRequest{})
+	if err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+	if resp.Status != healthpb.HealthCheckResponse_SERVING {
+		t.Errorf("got %v, want SERVING", resp.Status)
+	}
+	if got := limiter.InFlight(); got != 0 {
+		t.Errorf("InFlight() = %d, want 0 (disabled)", got)
+	}
+	if got := limiter.Capacity(); got != 0 {
+		t.Errorf("Capacity() = %d, want 0 (disabled)", got)
+	}
+}
+
+func TestLimiter_Capacity(t *testing.T) {
+	l := NewLimiter(42)
+	if got := l.Capacity(); got != 42 {
+		t.Errorf("Capacity() = %d, want 42", got)
+	}
+}


### PR DESCRIPTION
## Summary

Add a new `pkg/interceptors/concurrency` package that provides gRPC
client interceptors to cap the number of concurrent in-flight RPCs per
connection. When the limit is reached, new calls block until a slot
opens or the context is cancelled.

## Motivation

Addresses [CUS-237](https://linear.app/chainguard/issue/CUS-237) /
[CUS-172](https://linear.app/chainguard/issue/CUS-172) /
[chainguard-dev/internal-dev#18988](https://github.com/chainguard-dev/internal-dev/issues/18988).

During INC-44, uncapped concurrency allowed individual API server
instances to exhaust the load balancer's 250 connection limit. A
per-client concurrency limiter throttles each instance's contribution
to downstream load, providing backpressure before the downstream is
overwhelmed.

## Package API

```go
limiter := concurrency.NewLimiter(100) // 0 disables

opts := []grpc.DialOption{
    grpc.WithUnaryInterceptor(limiter.UnaryClientInterceptor()),
    grpc.WithStreamInterceptor(limiter.StreamClientInterceptor()),
}
```

## Behavior

| Scenario | Result |
|----------|--------|
| In-flight < limit | Call proceeds immediately |
| In-flight = limit | Call blocks until a slot opens |
| In-flight = limit + context cancelled | Returns context error as gRPC status |
| Limit = 0 | Interceptor is a no-op (passthrough) |
| Stream call | Slot held until RecvMsg returns error/EOF or context cancelled |

## Stream slot lifecycle

The stream interceptor acquires a slot before stream establishment and
releases it on the first of:
- `RecvMsg` returns an error (including `io.EOF`)
- The stream context is cancelled (safety net for abandoned streams)

Release uses `sync.Once` for thread-safe exactly-once semantics. If the
stream establishment itself fails, the slot is released immediately.

A background goroutine watches `stream.Context().Done()` to prevent
permanent slot leaks from abandoned streams where `RecvMsg` is never
drained (e.g., caller gives up, context cancelled before recv).

## Observability

- `limiter.InFlight()` — current number of in-flight RPCs (approximate
  under contention)
- `limiter.Capacity()` — configured maximum

These can be exported as Prometheus gauges by the caller if needed.

## Design decisions

**Semaphore over token bucket:** A semaphore caps concurrent load (the
direct cause of INC-44), while a token bucket caps request rate. Under
normal conditions with fast responses, a semaphore allows high throughput.
Under degraded conditions with slow responses, it naturally throttles
because slots aren't released — exactly the behavior we want.

**Opt-in per client:** Not added to the default `GRPCDialOptions()` since
the right limit varies by service (IAM needs more headroom than the
recommender). Callers enable it explicitly when dialing.

## Tests

- `TestLimiter_LimitsConcurrency` — 5 concurrent calls with limit 2,
  verifies server-side serving count never exceeds 2
- `TestLimiter_RespectsContextCancellation` — slot full + short context
  → DeadlineExceeded/Canceled
- `TestLimiter_DisabledWithZero` — limit 0 is a no-op passthrough
- `TestLimiter_StreamReleasesSlotOnRecvError` — stream holds slot,
  releases on RecvMsg error, slot is reusable for subsequent calls
- `TestLimiter_StreamReleasesSlotOnContextCancel` — stream holds slot,
  context cancelled without draining RecvMsg, safety net goroutine
  releases slot, slot is reusable for subsequent calls
- `TestLimiter_Capacity` — verifies Capacity() returns configured value

## Follow-up in mono

After bumping go-grpc-kit, enable per-client in
`api-impl/cmd/backend/main.go`'s `configureClients()`:

```go
limiter := concurrency.NewLimiter(100)
opts = append(opts, grpc.WithUnaryInterceptor(limiter.UnaryClientInterceptor()))
```

## Test plan

- [x] `go test ./pkg/interceptors/concurrency/ -v -race` — 6/6 pass
- [x] `golangci-lint run ./pkg/interceptors/concurrency/` — 0 issues
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)