### PR TITLE
feat(duplex): add graceful shutdown support and port validation

### DIFF
--- a/pkg/duplex/server.go
+++ b/pkg/duplex/server.go
@@ -7,6 +7,7 @@ package duplex
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -69,6 +70,9 @@ type RegisterHandlerFromEndpointFn func(ctx context.Context, mux *runtime.ServeM
 // for `grpc.NewServer`, typed `grpc.ServerOption`, and `runtime.NewServeMux`,
 // typed `runtime.ServeMuxOption`. Unknown opts will cause a panic.
 func New(port int, opts ...interface{}) *Duplex {
+	if port < 0 || port > 65535 {
+		panic(fmt.Sprintf("invalid port: %d", port))
+	}
 	// Split out the options into their types.
 	var (
 		gOpts []grpc.ServerOption
@@ -126,25 +130,70 @@ func (d *Duplex) RegisterHandler(ctx context.Context, fn RegisterHandlerFromEndp
 }
 
 // ListenAndServe starts both the gRPC server and HTTP Gateway MUX.
+// When the context is canceled, it gracefully stops the gRPC server and
+// shuts down the HTTP server, allowing in-flight requests to complete.
 // Note: This call is blocking.
-func (d *Duplex) ListenAndServe(_ context.Context) error {
+func (d *Duplex) ListenAndServe(ctx context.Context) error {
 	server := &http.Server{
 		Addr:              fmt.Sprintf("%s:%d", d.Host, d.Port),
 		Handler:           grpcHandlerFunc(d.Server, d.MUX),
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
-	return server.ListenAndServe()
+	return d.serveAndWait(ctx, server, func() error {
+		return server.ListenAndServe()
+	})
 }
 
 // Serve starts both the gRPC server and HTTP Gateway MUX on the given listener.
+// When the context is canceled, it gracefully stops the gRPC server and
+// shuts down the HTTP server, allowing in-flight requests to complete.
 // Note: This call is blocking.
-func (d *Duplex) Serve(_ context.Context, listener net.Listener) error {
+func (d *Duplex) Serve(ctx context.Context, listener net.Listener) error {
 	server := &http.Server{
 		Handler:           grpcHandlerFunc(d.Server, d.MUX),
 		ReadHeaderTimeout: 10 * time.Second,
 	}
-	return server.Serve(listener)
+
+	return d.serveAndWait(ctx, server, func() error {
+		return server.Serve(listener)
+	})
+}
+
+const shutdownTimeout = 30 * time.Second
+
+// serveAndWait runs serveFn in a goroutine and waits for either it to return
+// or for the context to be canceled, triggering graceful shutdown.
+//
+// The duplex server runs gRPC via grpcHandlerFunc on an http.Server, so
+// shutdown is driven by http.Server.Shutdown which gracefully drains both
+// REST and gRPC-over-HTTP connections. grpc.Server.GracefulStop is NOT
+// called because the serverHandlerTransport used in this mode does not
+// support Drain().
+func (d *Duplex) serveAndWait(ctx context.Context, server *http.Server, serveFn func() error) error {
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- serveFn()
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		// Gracefully shut down the HTTP server, allowing in-flight
+		// requests (both REST and gRPC-over-HTTP) to complete.
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("http shutdown: %w", err)
+		}
+
+		// Drain the serve error — http.ErrServerClosed is expected.
+		if err := <-errCh; err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
+		return nil
+	}
 }
 
 // RegisterListenAndServe initializes Prometheus metrics and starts a HTTP

--- a/pkg/duplex/server_test.go
+++ b/pkg/duplex/server_test.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -191,6 +192,113 @@ func TestMetrics(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestGracefulShutdown(t *testing.T) {
+	lis, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	ip, err := net.ResolveTCPAddr(lis.Addr().Network(), lis.Addr().String())
+	if err != nil {
+		t.Fatalf("error resolving: %v", err)
+	}
+
+	// Use a slow server to verify in-flight RPCs are drained.
+	impl := &slowServer{delay: 500 * time.Millisecond}
+	d := New(ip.Port,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	pb.RegisterGreeterServer(d.Server, impl)
+	if err := d.RegisterHandler(context.Background(), pb.RegisterGreeterHandlerFromEndpoint); err != nil {
+		t.Fatalf("error registering handler: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- d.Serve(ctx, lis)
+	}()
+
+	// Give server time to start.
+	time.Sleep(100 * time.Millisecond)
+
+	// Start a slow in-flight RPC.
+	conn, err := grpc.NewClient(lis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	defer conn.Close()
+	client := pb.NewGreeterClient(conn)
+
+	rpcDone := make(chan error, 1)
+	go func() {
+		_, err := client.SayHello(context.Background(), &pb.HelloRequest{Name: "drain"})
+		rpcDone <- err
+	}()
+
+	// Wait for the RPC to be in-flight, then cancel the server context.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	// The in-flight RPC should complete successfully (graceful drain).
+	select {
+	case err := <-rpcDone:
+		if err != nil {
+			t.Errorf("in-flight RPC failed during graceful shutdown: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("in-flight RPC did not complete within 5 seconds")
+	}
+
+	if impl.completed.Load() != 1 {
+		t.Errorf("expected 1 completed RPC, got %d", impl.completed.Load())
+	}
+
+	// Serve should return cleanly.
+	select {
+	case err := <-serveDone:
+		if err != nil {
+			t.Errorf("Serve returned error after graceful shutdown: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Serve did not return within 5 seconds after context cancellation")
+	}
+}
+
+func TestNewInvalidPort(t *testing.T) {
+	tests := []struct {
+		name string
+		port int
+	}{
+		{"negative", -1},
+		{"too large", 70000},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("expected panic for port %d", tt.port)
+				}
+			}()
+			New(tt.port)
+		})
+	}
+}
+
+// slowServer delays each RPC to test graceful shutdown drain behavior.
+type slowServer struct {
+	pb.UnimplementedGreeterServer
+	delay     time.Duration
+	completed atomic.Int64
+}
+
+func (s *slowServer) SayHello(_ context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
+	time.Sleep(s.delay)
+	s.completed.Add(1)
+	return &pb.HelloReply{Message: "Hello " + in.GetName()}, nil
 }
 
 // server is used to implement helloworld.GreeterServer.


### PR DESCRIPTION
## Summary
- Honor context cancellation in `ListenAndServe` and `Serve` by calling `http.Server.Shutdown()` when the context is done, allowing in-flight requests (both REST and gRPC-over-HTTP) to complete within a 30-second timeout
- Previously the context parameter was accepted but ignored (`_ context.Context`), meaning in-flight requests were dropped during deployments
- ~30 callers in mono already pass a `signal.NotifyContext` — they will automatically gain graceful shutdown on the next go-grpc-kit bump
- Also validate that port is in range `[0, 65535]` in `New()`

**Note:** `grpc.Server.GracefulStop()` is NOT used because the duplex server runs gRPC via `grpcHandlerFunc` on an `http.Server`, which uses `serverHandlerTransport` — a transport that does not support `Drain()`. `http.Server.Shutdown` handles graceful draining for both REST and gRPC-over-HTTP connections. The serve error channel is drained after shutdown and `http.ErrServerClosed` is filtered as expected.

## Test plan
- [x] `go test ./pkg/duplex/ -count=1 -race` passes
- [x] `TestGracefulShutdown` — starts a slow in-flight RPC, cancels the server context, verifies the RPC completes successfully (graceful drain) and Serve returns nil
- [x] `TestNewInvalidPort` — table-driven test verifying both negative and >65535 ports panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)