### PR TITLE
fix(metrics): restrict pprof endpoints to localhost only

### DIFF
--- a/pkg/metrics/pprof_test.go
+++ b/pkg/metrics/pprof_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package metrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLocalhostOnly_AllowsLoopback(t *testing.T) {
+	handler := localhostOnly(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/debug/pprof/", nil)
+	req.RemoteAddr = "127.0.0.1:12345"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 for loopback, got %d", rec.Code)
+	}
+}
+
+func TestLocalhostOnly_AllowsIPv6Loopback(t *testing.T) {
+	handler := localhostOnly(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/debug/pprof/", nil)
+	req.RemoteAddr = "[::1]:12345"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 for IPv6 loopback, got %d", rec.Code)
+	}
+}
+
+func TestLocalhostOnly_RejectsRemote(t *testing.T) {
+	handler := localhostOnly(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/debug/pprof/", nil)
+	req.RemoteAddr = "10.0.0.1:12345"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for remote IP, got %d", rec.Code)
+	}
+}

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -103,26 +103,44 @@ func getServer(enablePprof bool) *http.Server {
 	mux.Handle("/metrics", promhttp.Handler())
 
 	if enablePprof {
-		// pprof handles
-		mux.HandleFunc("/debug/pprof/", pprof.Index)
-		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-		mux.Handle("/debug/pprof/allocs", pprof.Handler("allocs"))
-		mux.Handle("/debug/pprof/block", pprof.Handler("block"))
-		mux.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
-		mux.Handle("/debug/pprof/heap", pprof.Handler("heap"))
-		mux.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
-		mux.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+		// pprof handles — restricted to loopback IPs only to prevent
+		// remote access to profiling data (goroutine stacks, heap, etc.).
+		mux.Handle("/debug/pprof/", localhostOnly(http.HandlerFunc(pprof.Index)))
+		mux.Handle("/debug/pprof/cmdline", localhostOnly(http.HandlerFunc(pprof.Cmdline)))
+		mux.Handle("/debug/pprof/profile", localhostOnly(http.HandlerFunc(pprof.Profile)))
+		mux.Handle("/debug/pprof/symbol", localhostOnly(http.HandlerFunc(pprof.Symbol)))
+		mux.Handle("/debug/pprof/trace", localhostOnly(http.HandlerFunc(pprof.Trace)))
+		mux.Handle("/debug/pprof/allocs", localhostOnly(pprof.Handler("allocs")))
+		mux.Handle("/debug/pprof/block", localhostOnly(pprof.Handler("block")))
+		mux.Handle("/debug/pprof/goroutine", localhostOnly(pprof.Handler("goroutine")))
+		mux.Handle("/debug/pprof/heap", localhostOnly(pprof.Handler("heap")))
+		mux.Handle("/debug/pprof/mutex", localhostOnly(pprof.Handler("mutex")))
+		mux.Handle("/debug/pprof/threadcreate", localhostOnly(pprof.Handler("threadcreate")))
 
-		log.Println("registering handle for /debug/pprof")
+		log.Println("registering handle for /debug/pprof (localhost-only)")
 	}
 
 	return &http.Server{
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
+}
+
+// localhostOnly wraps an http.Handler to reject requests from non-loopback IPs.
+func localhostOnly(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		host, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+		ip := net.ParseIP(host)
+		if ip == nil || !ip.IsLoopback() {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // Used ONLY for testing


### PR DESCRIPTION
## Summary
- Wrap all `/debug/pprof/` handlers with a localhost-only middleware
- Non-loopback IPs receive 403 Forbidden
- Prevents remote access to profiling data (goroutine stacks, heap profiles, CPU profiles)

## Motivation
When `enablePprof` is true and the metrics port is network-accessible, anyone can profile the process, view goroutine stacks (which may contain sensitive data in variable names), and trigger CPU profiles (mild DoS). In Cloud Run the metrics port is typically internal-only, but defense in depth is appropriate.

## Test plan
- [x] `go test ./pkg/metrics/ -count=1 -race` passes
- [x] `TestLocalhostOnly_AllowsLoopback` — IPv4 loopback allowed
- [x] `TestLocalhostOnly_AllowsIPv6Loopback` — IPv6 loopback allowed
- [x] `TestLocalhostOnly_RejectsRemote` — non-loopback rejected with 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)