### PR TITLE
feat(duplex): support graceful shutdown of the duplex server

### DIFF
--- a/pkg/duplex/inflight.go
+++ b/pkg/duplex/inflight.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package duplex
+
+import (
+	"context"
+	"sync"
+)
+
+// inflightTracker counts in-flight requests and lets a caller wait for them to
+// drain. Its zero value is ready to use.
+type inflightTracker struct {
+	mu    sync.Mutex
+	count int
+
+	// idle is created by the first waiter and closed when count reaches zero, so
+	// waiters can select on it alongside their context.
+	idle chan struct{}
+}
+
+func (t *inflightTracker) add() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.count++
+}
+
+func (t *inflightTracker) done() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.count--
+	if t.count == 0 && t.idle != nil {
+		close(t.idle)
+		t.idle = nil
+	}
+}
+
+// wait blocks until no requests are in flight, returning nil, or until ctx is
+// done, returning ctx.Err(). A ctx without a deadline waits indefinitely for
+// the count to reach zero.
+func (t *inflightTracker) wait(ctx context.Context) error {
+	t.mu.Lock()
+	if t.count == 0 {
+		t.mu.Unlock()
+		return nil
+	}
+
+	if t.idle == nil {
+		t.idle = make(chan struct{})
+	}
+	idle := t.idle
+	t.mu.Unlock()
+
+	select {
+	case <-idle:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/pkg/duplex/server.go
+++ b/pkg/duplex/server.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
@@ -23,17 +24,25 @@ import (
 	"chainguard.dev/go-grpc-kit/pkg/options"
 )
 
-// grpcHandlerFunc routes inbound requests to either the passed gRPC server or
-// the http handler based on the request content type.
+// handler routes inbound requests to either the gRPC server or the gateway MUX
+// based on the request content type, served over h2c so gRPC works on a
+// cleartext port. Each request is counted while it runs, so Shutdown can wait
+// for in-flight requests to finish: the gRPC requests are served over hijacked
+// h2c connections that http.Server.Shutdown does not track, so counting them
+// here is the only way to know when they have drained.
 // See also, https://grpc-ecosystem.github.io/grpc-gateway/
 // This is based on: https://github.com/philips/grpc-gateway-example/issues/22#issuecomment-490733965
-func grpcHandlerFunc(grpcServer *grpc.Server, httpHandler http.Handler) http.Handler {
+func (d *Duplex) handler() http.Handler {
 	return h2c.NewHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		d.inflight.add()
+		defer d.inflight.done()
+
 		if r.ProtoMajor == 2 && strings.Contains(r.Header.Get("Content-Type"), "application/grpc") {
-			grpcServer.ServeHTTP(w, r)
-		} else {
-			httpHandler.ServeHTTP(w, r)
+			d.Server.ServeHTTP(w, r)
+			return
 		}
+
+		d.MUX.ServeHTTP(w, r)
 	}), &http2.Server{})
 }
 
@@ -61,6 +70,13 @@ type Duplex struct {
 	Host        string
 	Port        int
 	DialOptions []grpc.DialOption
+
+	httpServerOnce sync.Once
+	httpServer     *http.Server
+
+	// inflight counts requests currently being served, so Shutdown can wait for
+	// them to finish.
+	inflight inflightTracker
 }
 
 type RegisterHandlerFromEndpointFn func(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error
@@ -126,25 +142,67 @@ func (d *Duplex) RegisterHandler(ctx context.Context, fn RegisterHandlerFromEndp
 }
 
 // ListenAndServe starts both the gRPC server and HTTP Gateway MUX.
-// Note: This call is blocking.
+// Note: This call is blocking. It returns http.ErrServerClosed after Shutdown.
 func (d *Duplex) ListenAndServe(_ context.Context) error {
-	server := &http.Server{
-		Addr:              fmt.Sprintf("%s:%d", d.Host, d.Port),
-		Handler:           grpcHandlerFunc(d.Server, d.MUX),
-		ReadHeaderTimeout: 10 * time.Second,
-	}
+	server := d.httpServerInstance()
+	server.Addr = fmt.Sprintf("%s:%d", d.Host, d.Port)
 
 	return server.ListenAndServe()
 }
 
 // Serve starts both the gRPC server and HTTP Gateway MUX on the given listener.
-// Note: This call is blocking.
+// Note: This call is blocking. It returns http.ErrServerClosed after Shutdown.
 func (d *Duplex) Serve(_ context.Context, listener net.Listener) error {
-	server := &http.Server{
-		Handler:           grpcHandlerFunc(d.Server, d.MUX),
-		ReadHeaderTimeout: 10 * time.Second,
-	}
-	return server.Serve(listener)
+	return d.httpServerInstance().Serve(listener)
+}
+
+// httpServerInstance returns the underlying http.Server, constructing it on
+// first use.
+func (d *Duplex) httpServerInstance() *http.Server {
+	d.httpServerOnce.Do(func() {
+		d.httpServer = &http.Server{
+			Handler:           d.handler(),
+			ReadHeaderTimeout: 10 * time.Second,
+		}
+	})
+
+	return d.httpServer
+}
+
+// Shutdown gracefully stops the duplex. It stops accepting new connections and
+// waits for in-flight requests to finish, bounded by ctx; if ctx is done before
+// they drain it stops waiting and returns ctx.Err(). After Shutdown returns, the
+// blocking ListenAndServe or Serve call returns http.ErrServerClosed.
+//
+// The wait is bounded only by ctx, mirroring http.Server.Shutdown: pass a
+// context with a deadline to cap it, or a long-lived request will hold shutdown
+// open indefinitely.
+//
+// gRPC is served over h2c, whose connections http.Server.Shutdown does not
+// track once hijacked, so its return does not imply gRPC has drained; and
+// grpc.Server.GracefulStop panics on a ServeHTTP-backed transport, so it cannot
+// drain them either. Shutdown therefore stops the listeners via the HTTP
+// server, waits on its own in-flight counter for requests of both kinds to
+// finish, then stops the gRPC server with grpc.Server.Stop and closes the HTTP
+// server. Those final steps run on every path: after a clean drain they release
+// the now-idle server; if the wait ended on ctx they also close transports that
+// are still open.
+func (d *Duplex) Shutdown(ctx context.Context) error {
+	server := d.httpServerInstance()
+
+	// Stop accepting new connections and drain the gateway's tracked
+	// connections. This does not wait for hijacked h2c (gRPC) connections, so
+	// run it in the background while the in-flight counter is drained below. Its
+	// error is dropped deliberately: the wait below reports the drain outcome,
+	// and the Close below is the backstop.
+	go func() { _ = server.Shutdown(ctx) }()
+
+	err := d.inflight.wait(ctx)
+
+	d.Server.Stop()
+	_ = server.Close()
+
+	return err
 }
 
 // RegisterListenAndServe initializes Prometheus metrics and starts a HTTP

--- a/pkg/duplex/server_test.go
+++ b/pkg/duplex/server_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -244,6 +245,180 @@ func TestHTTPLoopbackWithoutExplicitDialOptions(t *testing.T) {
 	if impl.lastClientID == "" {
 		t.Error("expected cgclientid on loopback request, got empty")
 	}
+}
+
+// TestShutdown verifies that Shutdown drains the duplex and unblocks the
+// serving goroutine: a request succeeds before shutdown, Shutdown returns
+// cleanly, and Serve then returns http.ErrServerClosed.
+func TestShutdown(t *testing.T) {
+	ctx := t.Context()
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d := New(0, grpc.ChainUnaryInterceptor(metrics.UnaryServerInterceptor()))
+	pb.RegisterGreeterServer(d.Server, &server{})
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- d.Serve(ctx, lis) }()
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	defer conn.Close()
+
+	client := pb.NewGreeterClient(conn)
+	if _, err := client.SayHello(ctx, &pb.HelloRequest{Name: "world"}); err != nil {
+		t.Fatalf("grpc request failed before shutdown: %v", err)
+	}
+
+	if err := d.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	if err := <-serveErr; err != nil && !errors.Is(err, http.ErrServerClosed) {
+		t.Fatalf("Serve returned unexpected error: %v", err)
+	}
+}
+
+// TestShutdownBeforeServe verifies that shutting down before serving starts is
+// safe and that a subsequent Serve returns immediately with http.ErrServerClosed
+// rather than starting to accept connections.
+func TestShutdownBeforeServe(t *testing.T) {
+	ctx := t.Context()
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lis.Close()
+
+	d := New(0)
+	pb.RegisterGreeterServer(d.Server, &server{})
+
+	if err := d.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown before serve: %v", err)
+	}
+
+	if err := d.Serve(ctx, lis); !errors.Is(err, http.ErrServerClosed) {
+		t.Fatalf("expected http.ErrServerClosed, got %v", err)
+	}
+}
+
+// TestShutdownDrainsInflight verifies that an in-flight request is allowed to
+// finish: with a request blocked in the handler, Shutdown waits for it, the
+// request completes successfully, and Shutdown then returns cleanly.
+func TestShutdownDrainsInflight(t *testing.T) {
+	ctx := t.Context()
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &blockingServer{started: make(chan struct{}, 1), release: make(chan struct{})}
+	d := New(0)
+	pb.RegisterGreeterServer(d.Server, srv)
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- d.Serve(ctx, lis) }()
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	defer conn.Close()
+
+	client := pb.NewGreeterClient(conn)
+
+	callErr := make(chan error, 1)
+	go func() {
+		_, err := client.SayHello(ctx, &pb.HelloRequest{Name: "world"})
+		callErr <- err
+	}()
+
+	<-srv.started // request is now in the handler
+
+	shutdownErr := make(chan error, 1)
+	go func() { shutdownErr <- d.Shutdown(ctx) }()
+
+	close(srv.release) // let the in-flight handler finish
+
+	if err := <-callErr; err != nil {
+		t.Fatalf("in-flight request failed during graceful shutdown: %v", err)
+	}
+	if err := <-shutdownErr; err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	if err := <-serveErr; err != nil && !errors.Is(err, http.ErrServerClosed) {
+		t.Fatalf("Serve returned unexpected error: %v", err)
+	}
+}
+
+// TestShutdownTimeoutStopsInflight verifies that when the drain exceeds the
+// context deadline, Shutdown returns the context error and the gRPC server is
+// stopped outright, cutting off the request that overstayed.
+func TestShutdownTimeoutStopsInflight(t *testing.T) {
+	ctx := t.Context()
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &blockingServer{started: make(chan struct{}, 1), release: make(chan struct{})}
+	t.Cleanup(func() { close(srv.release) })
+
+	d := New(0)
+	pb.RegisterGreeterServer(d.Server, srv)
+
+	go func() { _ = d.Serve(ctx, lis) }()
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	defer conn.Close()
+
+	client := pb.NewGreeterClient(conn)
+
+	callErr := make(chan error, 1)
+	go func() {
+		_, err := client.SayHello(ctx, &pb.HelloRequest{Name: "world"})
+		callErr <- err
+	}()
+
+	<-srv.started // request is now wedged in the handler
+
+	shutdownCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+	defer cancel()
+	if err := d.Shutdown(shutdownCtx); err == nil {
+		t.Fatal("expected Shutdown to return an error when the drain exceeds its deadline")
+	}
+
+	if err := <-callErr; err == nil {
+		t.Error("expected the in-flight request to fail once the server is stopped")
+	}
+}
+
+// blockingServer holds each SayHello in the handler until release is closed,
+// signaling started once a request has arrived. It lets a test drive the
+// duplex into a state where a request is genuinely in flight during shutdown.
+type blockingServer struct {
+	pb.UnimplementedGreeterServer
+
+	started chan struct{}
+	release chan struct{}
+}
+
+func (s *blockingServer) SayHello(_ context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
+	s.started <- struct{}{}
+	<-s.release
+	return &pb.HelloReply{Message: "Hello " + in.GetName()}, nil
 }
 
 // server is used to implement helloworld.GreeterServer.


### PR DESCRIPTION
Once `ListenAndServe` or `Serve` is running there is no clean way to stop the duplex. Both build a local `http.Server` and block on it, so a service that wants to drain its in-flight requests on `SIGTERM` has nothing to call. A caller is left reaching into `Duplex.Server` and calling `grpc.Server.Stop` itself, which closes the transports straight away and gives in-flight RPCs no chance to finish.

Draining cannot simply defer to `grpc.Server.GracefulStop`. Because the gRPC server is served over `h2c` through the HTTP server, it only ever holds `ServeHTTP`-backed transports, and `GracefulStop` panics when it tries to drain one of those. The connections belong to the HTTP server, so draining has to go through that server's `Shutdown`, after which `grpc.Server.Stop` can close anything that outlived the deadline.

This PR keeps a reference to the `http.Server` on the `Duplex` and adds `Shutdown(ctx)`, which performs that sequence: stop accepting new connections, wait for in-flight requests until the context is done, then stop the gRPC server. After `Shutdown` the blocking serve call returns `http.ErrServerClosed`; calling `Shutdown` before serving has started is safe and makes a later `Serve` return immediately. This gives a service a single call to make from its signal handler instead of re-deriving the h2c-safe drain sequence for itself.
