### PR TITLE
feat(options): dial unix domain socket targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ if err := d.ListenAndServe(ctx); err != nil {
 Pre-configured gRPC dial options for production use:
 
 - **`GRPCOptions(url)`** — Returns target address and dial options for a URL.
-  Handles `http`, `https`, `bufnet`, and test listener schemes.
+  Handles `http`, `https`, `unix`, `bufnet`, and test listener schemes.
 - **`GRPCDialOptions()`** — Standard dial options with OTEL tracing,
   Prometheus client metrics, client identity propagation, and retry support.
 - **`LoopbackDialOptions()`** — Minimal dial options for grpc-gateway

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -172,7 +172,7 @@ func grpcCallOptions() []grpc.CallOption {
 }
 
 // GRPCOptions returns a target address and dial options appropriate for the
-// given URL scheme (http, https, bufnet, or registered test listeners).
+// given URL scheme (http, https, unix, bufnet, or registered test listeners).
 func GRPCOptions(delegate url.URL) (string, []grpc.DialOption) {
 	switch delegate.Scheme {
 	case "http":
@@ -196,6 +196,13 @@ func GRPCOptions(delegate url.URL) (string, []grpc.DialOption) {
 			grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
 				MinVersion: tls.VersionTLS12,
 			})),
+			grpc.WithDefaultCallOptions(
+				grpcCallOptions()...,
+			)}...)
+
+	case "unix": // Local Unix domain socket, e.g. unix:///path/to/sock.
+		return delegate.String(), append(GRPCDialOptions(), []grpc.DialOption{
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
 			grpc.WithDefaultCallOptions(
 				grpcCallOptions()...,
 			)}...)

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -83,6 +83,45 @@ func TestGRPCOptions_HTTPSWithPort(t *testing.T) {
 	}
 }
 
+func TestGRPCOptions_Unix(t *testing.T) {
+	// The gRPC unix resolver requires an empty authority and reads the socket
+	// from the path (or opaque) component, so exercise each of the forms it
+	// accepts and confirm the returned target round-trips to an empty host.
+	cases := []struct {
+		name   string
+		target string
+	}{
+		{"absolute with authority", "unix:///tmp/example.sock"},
+		{"absolute without authority", "unix:/tmp/example.sock"},
+		{"relative opaque", "unix:example.sock"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := url.Parse(tc.target)
+			if err != nil {
+				t.Fatalf("parse %q: %v", tc.target, err)
+			}
+
+			addr, opts := GRPCOptions(*u)
+			if addr != tc.target {
+				t.Errorf("addr = %q, want %q", addr, tc.target)
+			}
+			if len(opts) == 0 {
+				t.Error("expected non-empty dial options")
+			}
+
+			parsed, err := url.Parse(addr)
+			if err != nil {
+				t.Fatalf("re-parse %q: %v", addr, err)
+			}
+			if parsed.Host != "" {
+				t.Errorf("target host = %q, want empty so the unix resolver accepts it", parsed.Host)
+			}
+		})
+	}
+}
+
 func TestGRPCOptions_TestListener(t *testing.T) {
 	lis, err := net.Listen("tcp", ":0")
 	if err != nil {


### PR DESCRIPTION
`GRPCOptions` understands `http`, `https`, `bufnet`, and registered test schemes, but not unix domain sockets; given anything else it panics. A client that wants to reach a co-located process over a unix socket therefore cannot use this package to build its dial options and has to assemble them by hand, duplicating the scheme parsing that already lives here.

This PR adds a `unix` case to `GRPCOptions` that dials the socket over the same interceptors as the other schemes. The target is passed through as given, so the standard `unix:` forms the gRPC resolver understands are all accepted.
