### PR TITLE
feat(options): add keepalive and dial-until-ready helpers

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 
 	"chainguard.dev/go-grpc-kit/pkg/interceptors/clientid"
 	"chainguard.dev/go-grpc-kit/pkg/trace"
@@ -120,6 +121,32 @@ var (
 	RecvMsgSize = 100 * 1024 * 1024 // 100MB
 	SendMsgSize = 100 * 1024 * 1024 // 100MB
 )
+
+const (
+	// keepaliveTime is how long a connection may be idle before the client
+	// pings it, so a black-holed connection is noticed between RPCs.
+	keepaliveTime = 30 * time.Second
+
+	// keepaliveTimeout is how long the client waits for a ping ack before it
+	// closes the connection and reconnects.
+	keepaliveTimeout = 20 * time.Second
+)
+
+// KeepaliveDialOption returns a dial option that pings an idle connection, so a
+// transport that has silently stopped passing traffic is closed and redialled
+// rather than holding the next RPC open until it times out. It pings even with
+// no active RPCs (PermitWithoutStream), so the server must be configured with a
+// matching keepalive.EnforcementPolicy (MinTime no greater than the ping
+// interval, and PermitWithoutStream true). A server using gRPC's defaults
+// rejects these pings with a GOAWAY, which is why this is offered as an opt-in
+// option rather than folded into GRPCDialOptions.
+func KeepaliveDialOption() grpc.DialOption {
+	return grpc.WithKeepaliveParams(keepalive.ClientParameters{
+		Time:                keepaliveTime,
+		Timeout:             keepaliveTimeout,
+		PermitWithoutStream: true,
+	})
+}
 
 // ClientOptions wraps GRPCDialOptions as google.golang.org/api/option.ClientOption
 // for use with Google API clients.

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
@@ -130,6 +131,10 @@ const (
 	// keepaliveTimeout is how long the client waits for a ping ack before it
 	// closes the connection and reconnects.
 	keepaliveTimeout = 20 * time.Second
+
+	// dialReadyTimeout is the default deadline DialReady waits for a transport
+	// to reach a ready state.
+	dialReadyTimeout = 30 * time.Second
 )
 
 // KeepaliveDialOption returns a dial option that pings an idle connection, so a
@@ -245,6 +250,42 @@ func GRPCOptions(delegate url.URL) (string, []grpc.DialOption) {
 			grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 				return listener.Dial()
 			}),
+		}
+	}
+}
+
+// DialReady opens a gRPC client connection to the target described by delegate
+// and blocks until its transport reaches a ready state, within timeout. A
+// timeout of zero applies the default deadline. The dial options for the
+// target's scheme (from GRPCOptions) are applied first, then opts. A target
+// that cannot be reached fails here rather than hanging the first RPC; the
+// returned connection is closed on failure.
+func DialReady(ctx context.Context, delegate url.URL, timeout time.Duration, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	if timeout <= 0 {
+		timeout = dialReadyTimeout
+	}
+
+	target, dialOpts := GRPCOptions(delegate)
+
+	conn, err := grpc.NewClient(target, append(dialOpts, opts...)...)
+	if err != nil {
+		return nil, err
+	}
+
+	conn.Connect()
+
+	deadline, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	for {
+		state := conn.GetState()
+		if state == connectivity.Ready {
+			return conn, nil
+		}
+
+		if !conn.WaitForStateChange(deadline, state) {
+			conn.Close()
+			return nil, fmt.Errorf("connect to %s: not ready within %s (last state %q): %w", target, timeout, state, deadline.Err())
 		}
 	}
 }

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -135,6 +135,12 @@ func TestClientOptions_ReturnsNonEmpty(t *testing.T) {
 	}
 }
 
+func TestKeepaliveDialOption(t *testing.T) {
+	if KeepaliveDialOption() == nil {
+		t.Error("expected a non-nil keepalive dial option")
+	}
+}
+
 type testDialableListener struct {
 	net.Listener
 }

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -6,13 +6,17 @@ SPDX-License-Identifier: Apache-2.0
 package options
 
 import (
+	"context"
 	"net"
 	"net/url"
 	"os"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 )
 
 func TestGetEnv(t *testing.T) {
@@ -138,6 +142,47 @@ func TestClientOptions_ReturnsNonEmpty(t *testing.T) {
 func TestKeepaliveDialOption(t *testing.T) {
 	if KeepaliveDialOption() == nil {
 		t.Error("expected a non-nil keepalive dial option")
+	}
+}
+
+func TestDialReady(t *testing.T) {
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+
+	srv := grpc.NewServer()
+	go func() { _ = srv.Serve(lis) }()
+	defer srv.Stop()
+
+	u := url.URL{Scheme: "http", Host: lis.Addr().String()}
+
+	conn, err := DialReady(context.Background(), u, time.Second)
+	if err != nil {
+		t.Fatalf("DialReady: %v", err)
+	}
+	defer conn.Close()
+
+	if state := conn.GetState(); state != connectivity.Ready {
+		t.Errorf("expected connection to be %s, got %s", connectivity.Ready, state)
+	}
+}
+
+func TestDialReady_UnreachableFails(t *testing.T) {
+	// Reserve a port, then close it so the dial is refused.
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	addr := lis.Addr().String()
+	lis.Close()
+
+	u := url.URL{Scheme: "http", Host: addr}
+
+	conn, err := DialReady(context.Background(), u, 500*time.Millisecond)
+	if err == nil {
+		conn.Close()
+		t.Fatal("expected DialReady to fail for an unreachable target")
 	}
 }
 


### PR DESCRIPTION
Two related client-dialing helpers, kept as separate commits so each carries its own rationale:

1. `feat(options): add an opt-in keepalive dial option` — A connection can stop passing traffic without either end noticing (a load balancer or NAT drops an idle flow), and nothing surfaces until the next RPC hangs until its own timeout. `KeepaliveDialOption` pings an idle connection so a dead transport is closed and redialled before the next RPC is sent. It pings even with no active stream, which the server must be configured to permit, so it is offered as a named option a caller opts into rather than folded into the shared defaults, where it could trip a server that does not allow such pings.

2. `feat(options): add DialReady to dial and wait for a ready transport` — `grpc.NewClient` is lazy, so an unreachable endpoint is not discovered until the first RPC, which then hangs until its own deadline. A client that wants to fail fast at startup has to drive the connectivity state machine itself. `DialReady` builds the connection from `GRPCOptions`, triggers it to connect, and blocks until the transport reports ready or a timeout elapses, closing the connection and returning an error on failure.

The second commit builds on the first (`DialReady`'s default-timeout constant lives alongside the keepalive constants), which is why they share a PR rather than splitting further.
