### PR TITLE
ci: always run Action lint so the required check reports

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -5,15 +5,9 @@ name: Action Lint
 on:
   pull_request:
     branches: ['main']
-    paths:
-      - '.github/workflows/**'
-      - '.github/actions/**'
 
   push:
     branches: ['main']
-    paths:
-      - '.github/workflows/**'
-      - '.github/actions/**'
 
 permissions: {}
 


### PR DESCRIPTION
## Problem

`Action lint` is a **required** status check under `main` branch
protection, but the `Action Lint` workflow is path-filtered to
`.github/workflows/**` and `.github/actions/**`.

GitHub's classic branch protection matches required checks by context
name on the PR head commit. When a workflow is skipped at the trigger
level (path filter doesn't match), the check run is **never created** —
so the `Action lint` context sits in `Expected — Waiting for status to
be reported` and the PR is blocked from merging. This affects every PR
that doesn't touch `.github/` (i.e. all normal code changes).

A job skipped via an `if:` condition reports `skipped` and counts as a
pass; a workflow that never triggers does not. This workflow is the
latter case.

## Fix

Drop the `paths:` filters so the workflow always runs and always
reports the `Action lint` context. `actionlint` is fast, so the extra
per-PR cost is negligible compared to PRs becoming unmergeable.

## Verification

- `actionlint .github/workflows/actionlint.yaml` → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)