### PR TITLE
fix(ci): GitHub Actions security hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  cooldown:
+    default-days: 3
   open-pull-requests-limit: 10
   groups:
     golang-org-x:
@@ -29,4 +31,6 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  cooldown:
+    default-days: 3
   open-pull-requests-limit: 10

--- a/.github/workflows/boilerplate.yaml
+++ b/.github/workflows/boilerplate.yaml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: chainguard-dev/actions/boilerplate@5f020827ba80ff5d64d45116542d0c733e8e7e71 # v1.6.23
         with:

--- a/.github/workflows/donotsubmit.yaml
+++ b/.github/workflows/donotsubmit.yaml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Do Not Submit
         uses: chainguard-dev/actions/donotsubmit@5f020827ba80ff5d64d45116542d0c733e8e7e71 # v1.6.23

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -27,6 +27,8 @@ jobs:
 
     - name: Check out code onto GOPATH
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
 
     # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
     - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -56,6 +58,8 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -80,6 +84,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -109,6 +115,8 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -64,7 +64,7 @@ jobs:
         ./hack/update-codegen.sh
 
     - name: Verify
-      uses: chainguard-dev/actions/nodiff@5f020827ba80ff5d64d45116542d0c733e8e7e71 # main
+      uses: chainguard-dev/actions/nodiff@5f020827ba80ff5d64d45116542d0c733e8e7e71 # v1.6.23
       with:
         path: ./src/github.com/${{ github.repository }}
         fixup-command: "./hack/update-codegen.sh"

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -34,6 +34,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
+        persist-credentials: false
         path: ./src/github.com/${{ github.repository }}
         fetch-depth: 0
 

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,15 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
 
 permissions: {}
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,15 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+rules:
+  # Paired with `cooldown.default-days: 3` in .github/dependabot.yml.
+  dependabot-cooldown:
+    config:
+      days: 3
+  # Cosmetic pedantic-only findings — suppressed across the campaign.
+  anonymous-definition:
+    disable: true
+  undocumented-permissions:
+    disable: true
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION
Automated GitHub Actions security hardening (zizmor + actionlint + shellcheck,
plus manual review). Workflow-config only — no application code is touched.

## Changes

- **Scope down checkout credentials** — `persist-credentials: false` on the
  eight checkout steps (across boilerplate / donotsubmit / go-test / style /
  verify) that do no downstream git writes, so the checkout token isn't left in
  `.git/config` for later steps.

- **Correct a pinned-action version comment** — the `chainguard-dev/actions/nodiff`
  step was pinned to a SHA but commented `# main`; corrected to the real tag
  (the same SHA every other step pins as that tag) so the pin is self-describing.

- **Add a zizmor config + dependabot cooldown** — a `.github/zizmor.yml`
  disabling a few cosmetic pedantic rules, plus a 3-day cooldown on each
  dependabot ecosystem so brand-new (and potentially compromised) dependency
  releases aren't pulled the instant they ship.

Refs: PSEC-923