### PR TITLE
  fix(metrics): normalize executable-derived gRPC client IDs

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -152,3 +152,4 @@ jobs:
           reporter: github-pr-check
           level: error
           fail-on-error: true
+          woke-version: v0.19.0

--- a/README.md
+++ b/README.md
@@ -81,4 +81,6 @@ Automatically propagates caller identity via gRPC metadata:
   `cgclientid` (service identity) and `cgrequestid` (unique per-call UUID)
   to outgoing metadata.
 
-Client ID resolution: `K_SERVICE` env → `CG_CLIENT_ID` env → executable path.
+Client ID resolution: `K_SERVICE` env → `CG_CLIENT_ID` env → executable name.
+Servers also normalize absolute executable paths from older clients before
+using them as metric labels.

--- a/pkg/interceptors/clientid/interceptors.go
+++ b/pkg/interceptors/clientid/interceptors.go
@@ -8,6 +8,7 @@ package clientid
 import (
 	"context"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/google/uuid"
@@ -19,20 +20,55 @@ const CGClientID = "cgclientid"
 const CGRequestID = "cgrequestid"
 
 var cachedClientID = sync.OnceValue(func() string {
-	// Prefer K_SERVICE (Cloud Run service name) for descriptive labels.
-	if svc := os.Getenv("K_SERVICE"); svc != "" {
-		return svc
+	kService := os.Getenv("K_SERVICE")
+	configuredID := os.Getenv("CG_CLIENT_ID")
+	if kService != "" || configuredID != "" {
+		return resolveClientID(kService, configuredID, "", nil)
 	}
-	// Prefer CG_CLIENT_ID for explicit override.
-	if id := os.Getenv("CG_CLIENT_ID"); id != "" {
-		return id
+	executable, err := os.Executable()
+	return resolveClientID("", "", executable, err)
+})
+
+func resolveClientID(kService, configuredID, executable string, executableErr error) string {
+	if kService != "" {
+		return kService
 	}
-	e, err := os.Executable()
-	if err != nil {
+	if configuredID != "" {
+		return configuredID
+	}
+	if executableErr != nil {
 		return "unknown"
 	}
-	return e
-})
+	return Normalize(executable)
+}
+
+// Normalize returns a stable executable name for absolute client ID paths.
+// Other client IDs are returned unchanged.
+func Normalize(id string) string {
+	if !isAbsolutePath(id) {
+		return id
+	}
+
+	trimmed := strings.TrimRight(id, `/\`)
+	if trimmed == "" {
+		return id
+	}
+	if separator := strings.LastIndexAny(trimmed, `/\`); separator >= 0 {
+		return trimmed[separator+1:]
+	}
+	return trimmed
+}
+
+func isAbsolutePath(value string) bool {
+	if strings.HasPrefix(value, "/") || strings.HasPrefix(value, `\\`) {
+		return true
+	}
+	return len(value) >= 3 && isASCIILetter(value[0]) && value[1] == ':' && (value[2] == '/' || value[2] == '\\')
+}
+
+func isASCIILetter(value byte) bool {
+	return value >= 'A' && value <= 'Z' || value >= 'a' && value <= 'z'
+}
 
 func appendClientID(ctx context.Context) context.Context {
 	// Always set this service's identity on outgoing calls so the

--- a/pkg/interceptors/clientid/interceptors_test.go
+++ b/pkg/interceptors/clientid/interceptors_test.go
@@ -7,6 +7,7 @@ package clientid
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"google.golang.org/grpc/metadata"
@@ -69,15 +70,68 @@ func TestAppendClientID_UniqueRequestIDs(t *testing.T) {
 	}
 }
 
-func TestCachedClientID_KServiceEnv(t *testing.T) {
-	// This tests the getClientID behavior indirectly via cachedClientID.
-	// Since cachedClientID uses sync.OnceValue, we test the logic directly.
-	t.Run("K_SERVICE takes precedence", func(t *testing.T) {
-		// We can't easily test the sync.OnceValue behavior since it's
-		// already initialized, but we verify the current value is non-empty.
-		id := cachedClientID()
-		if id == "" {
-			t.Error("cachedClientID should never be empty")
-		}
-	})
+func TestResolveClientID(t *testing.T) {
+	tests := []struct {
+		name          string
+		kService      string
+		configuredID  string
+		executable    string
+		executableErr error
+		want          string
+	}{
+		{
+			name:         "K_SERVICE takes precedence",
+			kService:     "oidc",
+			configuredID: "chainctl",
+			executable:   "/tmp/random/chainctl",
+			want:         "oidc",
+		},
+		{
+			name:         "CG_CLIENT_ID takes precedence over executable",
+			configuredID: "explicit/client",
+			executable:   "/tmp/random/chainctl",
+			want:         "explicit/client",
+		},
+		{
+			name:       "executable fallback is normalized",
+			executable: "/tmp/random/chainctl",
+			want:       "chainctl",
+		},
+		{
+			name:          "executable lookup failure",
+			executableErr: errors.New("lookup failed"),
+			want:          "unknown",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := resolveClientID(test.kService, test.configuredID, test.executable, test.executableErr); got != test.want {
+				t.Errorf("resolveClientID() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{name: "Unix path", id: "/tmp/random/chainctl", want: "chainctl"},
+		{name: "Windows drive path", id: `C:\Temp\random\chainctl.exe`, want: "chainctl.exe"},
+		{name: "Windows UNC path", id: `\\server\share\chainctl.exe`, want: "chainctl.exe"},
+		{name: "relative path", id: "tmp/random/chainctl", want: "tmp/random/chainctl"},
+		{name: "service ID", id: "prober/oidc", want: "prober/oidc"},
+		{name: "empty", id: "", want: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := Normalize(test.id); got != test.want {
+				t.Errorf("Normalize(%q) = %q, want %q", test.id, got, test.want)
+			}
+		})
+	}
 }

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -92,7 +92,7 @@ func SetupTracer(ctx context.Context) func() {
 func labelsFromContext(ctx context.Context) prometheus.Labels {
 	cid := "unknown"
 	if clientids := metadata.ValueFromIncomingContext(ctx, clientid.CGClientID); len(clientids) > 0 {
-		cid = clientids[0]
+		cid = clientid.Normalize(clientids[0])
 	}
 	return prometheus.Labels{clientid.CGClientID: cid}
 }

--- a/pkg/metrics/server_test.go
+++ b/pkg/metrics/server_test.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package metrics
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -13,7 +14,36 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"google.golang.org/grpc/metadata"
+
+	"chainguard.dev/go-grpc-kit/pkg/interceptors/clientid"
 )
+
+func TestLabelsFromContext(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{name: "missing", want: "unknown"},
+		{name: "Unix executable path", id: "/tmp/random/chainctl", want: "chainctl"},
+		{name: "Windows executable path", id: `C:\Temp\random\chainctl.exe`, want: "chainctl.exe"},
+		{name: "service ID", id: "issuer", want: "issuer"},
+		{name: "relative service ID", id: "prober/issuer", want: "prober/issuer"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			if test.id != "" {
+				ctx = metadata.NewIncomingContext(ctx, metadata.Pairs(clientid.CGClientID, test.id))
+			}
+			if got := labelsFromContext(ctx)[clientid.CGClientID]; got != test.want {
+				t.Errorf("labelsFromContext() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
 
 // brokenCollector is a prometheus.Collector that always returns an error
 // during collection, simulating the OTel prometheus exporter behavior


### PR DESCRIPTION
## Summary

Normalize executable fallback client IDs to stable executable names. Server metrics also collapse absolute paths from older clients while preserving service style identifiers.

For OIDC, this collapses randomized chainctl paths in cgclientid to a stable value, reducing the cardinality that caused metric drops without changing the metrics or scrape  interval.