### PR TITLE
metrics: record gRPC client transport delays

### DIFF
--- a/pkg/metrics/client.go
+++ b/pkg/metrics/client.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2026 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package metrics provides Prometheus metrics for gRPC transport behavior.
+package metrics
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"google.golang.org/grpc/stats"
+)
+
+type clientTransportMetrics struct {
+	dispatchDelay  *prometheus.HistogramVec
+	activeAttempts *prometheus.GaugeVec
+}
+
+const (
+	clientAttemptPhasePending  = "pending"
+	clientAttemptPhaseInFlight = "in_flight"
+)
+
+var clientMetrics = sync.OnceValue(func() *clientTransportMetrics {
+	return newClientTransportMetrics(prometheus.DefaultRegisterer)
+})
+
+func newClientTransportMetrics(registerer prometheus.Registerer) *clientTransportMetrics {
+	factory := promauto.With(registerer)
+	labels := []string{"grpc_service", "grpc_method"}
+
+	return &clientTransportMetrics{
+		dispatchDelay: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "grpc_client_attempt_dispatch_delay_seconds",
+			Help:    "Time from starting a gRPC client attempt until it is dispatched to a transport.",
+			Buckets: []float64{0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.5, 1, 2.5, 5, 10, 25, 60},
+		}, labels),
+		activeAttempts: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "grpc_client_attempts_active",
+			Help: "Number of active gRPC client attempts by transport phase.",
+		}, append(labels, "phase")),
+	}
+}
+
+// ClientStatsHandler returns a stats handler that records how long client
+// attempts wait for a transport and tracks active attempts before and after
+// dispatch. Install it with grpc.WithStatsHandler.
+//
+// Each attempt, including retries, is measured separately. Attempts that end
+// before dispatch are removed from the pending gauge but do not contribute to
+// the dispatch delay histogram.
+func ClientStatsHandler() stats.Handler {
+	return newClientStatsHandler(clientMetrics(), time.Now)
+}
+
+type clientRPCState struct {
+	beginTime  time.Time
+	service    string
+	method     string
+	dispatched bool
+}
+
+type clientStatsHandler struct {
+	metrics *clientTransportMetrics
+	now     func() time.Time
+}
+
+func newClientStatsHandler(metrics *clientTransportMetrics, now func() time.Time) stats.Handler {
+	return &clientStatsHandler{
+		metrics: metrics,
+		now:     now,
+	}
+}
+
+type clientRPCStateKey struct{}
+
+func (*clientStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
+	service, method := splitGRPCMethod(info.FullMethodName)
+	return context.WithValue(ctx, clientRPCStateKey{}, &clientRPCState{
+		service: service,
+		method:  method,
+	})
+}
+
+func (h *clientStatsHandler) HandleRPC(ctx context.Context, event stats.RPCStats) {
+	state, ok := ctx.Value(clientRPCStateKey{}).(*clientRPCState)
+	if !ok {
+		return
+	}
+
+	switch event := event.(type) {
+	case *stats.Begin:
+		state.beginTime = event.BeginTime
+		h.metrics.activeAttempts.WithLabelValues(state.service, state.method, clientAttemptPhasePending).Inc()
+	case *stats.OutHeader:
+		duration := h.now().Sub(state.beginTime)
+		if duration < 0 {
+			duration = 0
+		}
+		h.metrics.dispatchDelay.WithLabelValues(state.service, state.method).Observe(duration.Seconds())
+		h.metrics.activeAttempts.WithLabelValues(state.service, state.method, clientAttemptPhasePending).Dec()
+		h.metrics.activeAttempts.WithLabelValues(state.service, state.method, clientAttemptPhaseInFlight).Inc()
+		state.dispatched = true
+	case *stats.End:
+		phase := clientAttemptPhasePending
+		if state.dispatched {
+			phase = clientAttemptPhaseInFlight
+		}
+		h.metrics.activeAttempts.WithLabelValues(state.service, state.method, phase).Dec()
+	}
+}
+
+func (*clientStatsHandler) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+func (*clientStatsHandler) HandleConn(context.Context, stats.ConnStats) {}
+
+func splitGRPCMethod(fullMethod string) (string, string) {
+	trimmed := strings.TrimPrefix(fullMethod, "/")
+	service, method, ok := strings.Cut(trimmed, "/")
+	if !ok || service == "" || method == "" {
+		return "unknown", "unknown"
+	}
+	return service, method
+}

--- a/pkg/metrics/client.go
+++ b/pkg/metrics/client.go
@@ -33,18 +33,19 @@ var clientMetrics = sync.OnceValue(func() *clientTransportMetrics {
 
 func newClientTransportMetrics(registerer prometheus.Registerer) *clientTransportMetrics {
 	factory := promauto.With(registerer)
-	labels := []string{"grpc_service", "grpc_method"}
+	dispatchLabels := []string{"grpc_service", "grpc_method"}
+	activeLabels := []string{"grpc_service", "grpc_method", "phase"}
 
 	return &clientTransportMetrics{
 		dispatchDelay: factory.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "grpc_client_attempt_dispatch_delay_seconds",
 			Help:    "Time from starting a gRPC client attempt until it is dispatched to a transport.",
 			Buckets: []float64{0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.5, 1, 2.5, 5, 10, 25, 60},
-		}, labels),
+		}, dispatchLabels),
 		activeAttempts: factory.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "grpc_client_attempts_active",
 			Help: "Number of active gRPC client attempts by transport phase.",
-		}, append(labels, "phase")),
+		}, activeLabels),
 	}
 }
 

--- a/pkg/metrics/client.go
+++ b/pkg/metrics/client.go
@@ -18,14 +18,8 @@ import (
 )
 
 type clientTransportMetrics struct {
-	dispatchDelay  *prometheus.HistogramVec
-	activeAttempts *prometheus.GaugeVec
+	dispatchDelay *prometheus.HistogramVec
 }
-
-const (
-	clientAttemptPhasePending  = "pending"
-	clientAttemptPhaseInFlight = "in_flight"
-)
 
 var clientMetrics = sync.OnceValue(func() *clientTransportMetrics {
 	return newClientTransportMetrics(prometheus.DefaultRegisterer)
@@ -33,38 +27,29 @@ var clientMetrics = sync.OnceValue(func() *clientTransportMetrics {
 
 func newClientTransportMetrics(registerer prometheus.Registerer) *clientTransportMetrics {
 	factory := promauto.With(registerer)
-	dispatchLabels := []string{"grpc_service", "grpc_method"}
-	activeLabels := []string{"grpc_service", "grpc_method", "phase"}
 
 	return &clientTransportMetrics{
 		dispatchDelay: factory.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "grpc_client_attempt_dispatch_delay_seconds",
 			Help:    "Time from starting a gRPC client attempt until it is dispatched to a transport.",
 			Buckets: []float64{0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.5, 1, 2.5, 5, 10, 25, 60},
-		}, dispatchLabels),
-		activeAttempts: factory.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "grpc_client_attempts_active",
-			Help: "Number of active gRPC client attempts by transport phase.",
-		}, activeLabels),
+		}, []string{"grpc_service", "grpc_method"}),
 	}
 }
 
 // ClientStatsHandler returns a stats handler that records how long client
-// attempts wait for a transport and tracks active attempts before and after
-// dispatch. Install it with grpc.WithStatsHandler.
+// attempts wait for a transport. Install it with grpc.WithStatsHandler.
 //
 // Each attempt, including retries, is measured separately. Attempts that end
-// before dispatch are removed from the pending gauge but do not contribute to
-// the dispatch delay histogram.
+// before dispatch do not contribute to the dispatch delay histogram.
 func ClientStatsHandler() stats.Handler {
 	return newClientStatsHandler(clientMetrics(), time.Now)
 }
 
 type clientRPCState struct {
-	beginTime  time.Time
-	service    string
-	method     string
-	dispatched bool
+	beginTime time.Time
+	service   string
+	method    string
 }
 
 type clientStatsHandler struct {
@@ -98,22 +83,15 @@ func (h *clientStatsHandler) HandleRPC(ctx context.Context, event stats.RPCStats
 	switch event := event.(type) {
 	case *stats.Begin:
 		state.beginTime = event.BeginTime
-		h.metrics.activeAttempts.WithLabelValues(state.service, state.method, clientAttemptPhasePending).Inc()
 	case *stats.OutHeader:
+		if state.beginTime.IsZero() {
+			return
+		}
 		duration := h.now().Sub(state.beginTime)
 		if duration < 0 {
-			duration = 0
+			return
 		}
 		h.metrics.dispatchDelay.WithLabelValues(state.service, state.method).Observe(duration.Seconds())
-		h.metrics.activeAttempts.WithLabelValues(state.service, state.method, clientAttemptPhasePending).Dec()
-		h.metrics.activeAttempts.WithLabelValues(state.service, state.method, clientAttemptPhaseInFlight).Inc()
-		state.dispatched = true
-	case *stats.End:
-		phase := clientAttemptPhasePending
-		if state.dispatched {
-			phase = clientAttemptPhaseInFlight
-		}
-		h.metrics.activeAttempts.WithLabelValues(state.service, state.method, phase).Dec()
 	}
 }
 

--- a/pkg/metrics/client_test.go
+++ b/pkg/metrics/client_test.go
@@ -11,65 +11,146 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/testutil"
 	"google.golang.org/grpc/stats"
 )
 
 func TestClientStatsHandler(t *testing.T) {
-	registerer := prometheus.NewRegistry()
-	metrics := newClientTransportMetrics(registerer)
 	start := time.Unix(0, 0)
-	handler := newClientStatsHandler(metrics, func() time.Time {
-		return start.Add(250 * time.Millisecond)
-	})
-	labels := []string{"test.Service", "Method"}
+	for _, test := range []struct {
+		name      string
+		tagged    bool
+		now       time.Time
+		events    []stats.RPCStats
+		wantCount uint64
+		wantSum   float64
+	}{
+		{
+			name:   "dispatch delay",
+			tagged: true,
+			now:    start.Add(250 * time.Millisecond),
+			events: []stats.RPCStats{
+				&stats.Begin{Client: true, BeginTime: start},
+				&stats.OutHeader{Client: true},
+			},
+			wantCount: 1,
+			wantSum:   0.25,
+		},
+		{
+			name:   "clock moves backward",
+			tagged: true,
+			now:    start,
+			events: []stats.RPCStats{
+				&stats.Begin{Client: true, BeginTime: start.Add(time.Second)},
+				&stats.OutHeader{Client: true},
+			},
+		},
+		{
+			name: "untagged context",
+			now:  start.Add(250 * time.Millisecond),
+			events: []stats.RPCStats{
+				&stats.Begin{Client: true, BeginTime: start},
+				&stats.OutHeader{Client: true},
+			},
+		},
+		{
+			name:   "header without begin",
+			tagged: true,
+			now:    start.Add(250 * time.Millisecond),
+			events: []stats.RPCStats{
+				&stats.OutHeader{Client: true},
+			},
+		},
+		{
+			name:   "ends before dispatch",
+			tagged: true,
+			now:    start.Add(250 * time.Millisecond),
+			events: []stats.RPCStats{
+				&stats.Begin{Client: true, BeginTime: start},
+				&stats.End{Client: true},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			registerer := prometheus.NewRegistry()
+			metrics := newClientTransportMetrics(registerer)
+			handler := newClientStatsHandler(metrics, func() time.Time { return test.now })
+			ctx := context.Background()
+			if test.tagged {
+				ctx = handler.TagRPC(ctx, &stats.RPCTagInfo{FullMethodName: "/test.Service/Method"})
+			}
+			for _, event := range test.events {
+				handler.HandleRPC(ctx, event)
+			}
 
-	ctx := handler.TagRPC(context.Background(), &stats.RPCTagInfo{
-		FullMethodName: "/test.Service/Method",
-	})
-	handler.HandleRPC(ctx, &stats.Begin{Client: true, BeginTime: start})
-	if got, want := testutil.ToFloat64(metrics.activeAttempts.WithLabelValues(append(labels, clientAttemptPhasePending)...)), float64(1); got != want {
-		t.Fatalf("pending attempts after Begin = %v, want %v", got, want)
+			gotCount, gotSum := dispatchHistogram(t, registerer)
+			if gotCount != test.wantCount || gotSum != test.wantSum {
+				t.Fatalf("dispatch-delay histogram = count %d, sum %v; want count %d, sum %v", gotCount, gotSum, test.wantCount, test.wantSum)
+			}
+		})
 	}
+}
 
-	handler.HandleRPC(ctx, &stats.OutHeader{Client: true})
-	if got, want := testutil.ToFloat64(metrics.activeAttempts.WithLabelValues(append(labels, clientAttemptPhasePending)...)), float64(0); got != want {
-		t.Fatalf("pending attempts after OutHeader = %v, want %v", got, want)
+func TestSplitGRPCMethod(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		fullMethod  string
+		wantService string
+		wantMethod  string
+	}{
+		{
+			name:        "valid",
+			fullMethod:  "/test.Service/Method",
+			wantService: "test.Service",
+			wantMethod:  "Method",
+		},
+		{
+			name:        "missing separator",
+			fullMethod:  "Method",
+			wantService: "unknown",
+			wantMethod:  "unknown",
+		},
+		{
+			name:        "missing method",
+			fullMethod:  "/test.Service/",
+			wantService: "unknown",
+			wantMethod:  "unknown",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			service, method := splitGRPCMethod(test.fullMethod)
+			if service != test.wantService || method != test.wantMethod {
+				t.Fatalf("splitGRPCMethod(%q) = %q, %q; want %q, %q", test.fullMethod, service, method, test.wantService, test.wantMethod)
+			}
+		})
 	}
-	if got, want := testutil.ToFloat64(metrics.activeAttempts.WithLabelValues(append(labels, clientAttemptPhaseInFlight)...)), float64(1); got != want {
-		t.Fatalf("in-flight attempts after OutHeader = %v, want %v", got, want)
-	}
-	handler.HandleRPC(ctx, &stats.End{Client: true})
-	if got, want := testutil.ToFloat64(metrics.activeAttempts.WithLabelValues(append(labels, clientAttemptPhaseInFlight)...)), float64(0); got != want {
-		t.Fatalf("in-flight attempts after End = %v, want %v", got, want)
-	}
+}
 
+func dispatchHistogram(t *testing.T, registerer *prometheus.Registry) (uint64, float64) {
+	t.Helper()
 	families, err := registerer.Gather()
 	if err != nil {
 		t.Fatalf("gathering metrics: %v", err)
 	}
-	found := false
 	for _, family := range families {
 		if family.GetName() != "grpc_client_attempt_dispatch_delay_seconds" {
 			continue
 		}
-		found = true
-		got := family.GetMetric()[0].GetHistogram()
-		if got.GetSampleCount() != 1 || got.GetSampleSum() != 0.25 {
-			t.Fatalf("dispatch-delay histogram = count %d, sum %v; want count 1, sum 0.25", got.GetSampleCount(), got.GetSampleSum())
+		if got, want := len(family.GetMetric()), 1; got != want {
+			t.Fatalf("dispatch-delay series = %d; want %d", got, want)
 		}
-		break
+		metric := family.GetMetric()[0]
+		labels := map[string]string{}
+		for _, label := range metric.GetLabel() {
+			labels[label.GetName()] = label.GetValue()
+		}
+		if got, want := labels["grpc_service"], "test.Service"; got != want {
+			t.Fatalf("grpc_service label = %q; want %q", got, want)
+		}
+		if got, want := labels["grpc_method"], "Method"; got != want {
+			t.Fatalf("grpc_method label = %q; want %q", got, want)
+		}
+		got := metric.GetHistogram()
+		return got.GetSampleCount(), got.GetSampleSum()
 	}
-	if !found {
-		t.Fatal("dispatch-delay histogram was not collected")
-	}
-
-	failedCtx := handler.TagRPC(context.Background(), &stats.RPCTagInfo{
-		FullMethodName: "/test.Service/Method",
-	})
-	handler.HandleRPC(failedCtx, &stats.Begin{Client: true, BeginTime: start})
-	handler.HandleRPC(failedCtx, &stats.End{Client: true})
-	if got, want := testutil.ToFloat64(metrics.activeAttempts.WithLabelValues(append(labels, clientAttemptPhasePending)...)), float64(0); got != want {
-		t.Fatalf("pending attempts after End without OutHeader = %v, want %v", got, want)
-	}
+	return 0, 0
 }

--- a/pkg/metrics/client_test.go
+++ b/pkg/metrics/client_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package metrics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"google.golang.org/grpc/stats"
+)
+
+func TestClientStatsHandler(t *testing.T) {
+	registerer := prometheus.NewRegistry()
+	metrics := newClientTransportMetrics(registerer)
+	start := time.Unix(0, 0)
+	handler := newClientStatsHandler(metrics, func() time.Time {
+		return start.Add(250 * time.Millisecond)
+	})
+	labels := []string{"test.Service", "Method"}
+
+	ctx := handler.TagRPC(context.Background(), &stats.RPCTagInfo{
+		FullMethodName: "/test.Service/Method",
+	})
+	handler.HandleRPC(ctx, &stats.Begin{Client: true, BeginTime: start})
+	if got, want := testutil.ToFloat64(metrics.activeAttempts.WithLabelValues(append(labels, clientAttemptPhasePending)...)), float64(1); got != want {
+		t.Fatalf("pending attempts after Begin = %v, want %v", got, want)
+	}
+
+	handler.HandleRPC(ctx, &stats.OutHeader{Client: true})
+	if got, want := testutil.ToFloat64(metrics.activeAttempts.WithLabelValues(append(labels, clientAttemptPhasePending)...)), float64(0); got != want {
+		t.Fatalf("pending attempts after OutHeader = %v, want %v", got, want)
+	}
+	if got, want := testutil.ToFloat64(metrics.activeAttempts.WithLabelValues(append(labels, clientAttemptPhaseInFlight)...)), float64(1); got != want {
+		t.Fatalf("in-flight attempts after OutHeader = %v, want %v", got, want)
+	}
+	handler.HandleRPC(ctx, &stats.End{Client: true})
+	if got, want := testutil.ToFloat64(metrics.activeAttempts.WithLabelValues(append(labels, clientAttemptPhaseInFlight)...)), float64(0); got != want {
+		t.Fatalf("in-flight attempts after End = %v, want %v", got, want)
+	}
+
+	families, err := registerer.Gather()
+	if err != nil {
+		t.Fatalf("gathering metrics: %v", err)
+	}
+	found := false
+	for _, family := range families {
+		if family.GetName() != "grpc_client_attempt_dispatch_delay_seconds" {
+			continue
+		}
+		found = true
+		got := family.GetMetric()[0].GetHistogram()
+		if got.GetSampleCount() != 1 || got.GetSampleSum() != 0.25 {
+			t.Fatalf("dispatch-delay histogram = count %d, sum %v; want count 1, sum 0.25", got.GetSampleCount(), got.GetSampleSum())
+		}
+		break
+	}
+	if !found {
+		t.Fatal("dispatch-delay histogram was not collected")
+	}
+
+	failedCtx := handler.TagRPC(context.Background(), &stats.RPCTagInfo{
+		FullMethodName: "/test.Service/Method",
+	})
+	handler.HandleRPC(failedCtx, &stats.Begin{Client: true, BeginTime: start})
+	handler.HandleRPC(failedCtx, &stats.End{Client: true})
+	if got, want := testutil.ToFloat64(metrics.activeAttempts.WithLabelValues(append(labels, clientAttemptPhasePending)...)), float64(0); got != want {
+		t.Fatalf("pending attempts after End without OutHeader = %v, want %v", got, want)
+	}
+}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/keepalive"
 
 	"chainguard.dev/go-grpc-kit/pkg/interceptors/clientid"
+	kitmetrics "chainguard.dev/go-grpc-kit/pkg/metrics"
 	"chainguard.dev/go-grpc-kit/pkg/trace"
 	"github.com/chainguard-dev/clog"
 )
@@ -189,6 +190,7 @@ func GRPCDialOptions() []grpc.DialOption {
 
 	return []grpc.DialOption{
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+		grpc.WithStatsHandler(kitmetrics.ClientStatsHandler()),
 		grpc.WithStatsHandler(trace.PreserveTraceParentHandler),
 		grpc.WithChainUnaryInterceptor(clientid.UnaryClientInterceptor(), state().clientMetrics.UnaryClientInterceptor(), grpc_retry.UnaryClientInterceptor(retryOpts...)),
 		grpc.WithChainStreamInterceptor(clientid.StreamClientInterceptor(), state().clientMetrics.StreamClientInterceptor(), grpc_retry.StreamClientInterceptor(retryOpts...)),


### PR DESCRIPTION
Client RPC latency alone does not reveal whether time was spent waiting in the client transport or executing in the downstream service. Record the delay between starting an RPC call and actually sending its headers out on the transport. Attach the shared handler to production dial options so services collect these metrics automatically.

The delay histogram quantifies the latency added before dispatch. This metric can help identify HTTP/2 stream saturation and distinguish client-side queueing from downstream service latency.